### PR TITLE
Fix nonce type annotation in PromotionalOfferSignatureCreator

### DIFF
--- a/appstoreserverlibrary/promotional_offer.py
+++ b/appstoreserverlibrary/promotional_offer.py
@@ -16,7 +16,7 @@ class PromotionalOfferSignatureCreator:
        self._signing_key = serialization.load_pem_private_key(signing_key, password=None, backend=default_backend())
        self._key_id = key_id
        self._bundle_id = bundle_id
-    def create_signature(self, product_identifier: str, subscription_offer_id: str, application_username: str, nonce: uuid, timestamp: int):
+    def create_signature(self, product_identifier: str, subscription_offer_id: str, application_username: str, nonce: uuid.UUID, timestamp: int):
         """
         Return the Base64 encoded signature
 


### PR DESCRIPTION
The old annotation for nonce was `uuid` the module, not `uuid.UUID` the actual [UUID](https://docs.python.org/3/library/uuid.html#uuid.UUID) type in Python.

This will help with type checking once that works (see #15) and fixes the [rendering of the docs](https://app-store-server-library.readthedocs.io/en/latest/appstoreserverlibrary.promotional_offer.html#appstoreserverlibrary.promotional_offer.PromotionalOfferSignatureCreator.create_signature). Those docs used to render like so:
```
create_signature(product_identifier: str, subscription_offer_id: str, application_username: str, nonce: <module 'uuid' from '/home/docs/.asdf/installs/python/3.11.4/lib/python3.11/uuid.py'>, timestamp: int)
```
and should now render like so:
```
create_signature(product_identifier: str, subscription_offer_id: str, application_username: str, nonce: uuid.UUID, timestamp: int)
```