### PR TITLE
exclude tests package from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     description="The App Store Server Library",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    packages=find_packages(),
+    packages=find_packages(exclude=["tests"]),
     python_requires=">=3.7, <4",
     install_requires=["attrs >= 21.3.0", 'PyJWT >= 2.6.0, < 3', 'requests >= 2.28.0, < 3', 'cryptography >= 40.0.0, < 42', 'pyOpenSSL >= 23.1.1, < 24', 'asn1==2.7.0', 'cattrs==23.1.2'],
     package_data={"appstoreserverlibrary": ["py.typed"]},


### PR DESCRIPTION
Fixes https://github.com/apple/app-store-server-library-python/issues/29.