### PR TITLE
Readme tweak patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ The Python server library for the [App Store Server API](https://developer.apple
 
 - Python 3.7+
 
-### Gradle
-```groovy
+### pip
+```sh
 pip install app-store-server-library
 ```
 


### PR DESCRIPTION
## WHY

- Maybe the tool name is pulling from the Java library description.