### PR TITLE
Bump cryptography and pyOpenSSL maximum version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,6 @@ setup(
     long_description_content_type="text/markdown",
     packages=find_packages(exclude=["tests"]),
     python_requires=">=3.7, <4",
-    install_requires=["attrs >= 21.3.0", 'PyJWT >= 2.6.0, < 3', 'requests >= 2.28.0, < 3', 'cryptography >= 40.0.0, < 42', 'pyOpenSSL >= 23.1.1, < 24', 'asn1==2.7.0', 'cattrs==23.1.2'],
+    install_requires=["attrs >= 21.3.0", 'PyJWT >= 2.6.0, < 3', 'requests >= 2.28.0, < 3', 'cryptography >= 40.0.0', 'pyOpenSSL >= 23.1.1, < 25', 'asn1==2.7.0', 'cattrs==23.1.2'],
     package_data={"appstoreserverlibrary": ["py.typed"]},
 )


### PR DESCRIPTION
As a follow up to https://github.com/apple/app-store-server-library-python/pull/61, requirements also need to be updatd in setup.py.