### PR TITLE
fix: update code and method annotation

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -54,7 +54,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 _____________________
 
-requests contirbutors (requests)
+requests contributors (requests)
 
              Apache License
                            Version 2.0, January 2004

--- a/appstoreserverlibrary/api_client.py
+++ b/appstoreserverlibrary/api_client.py
@@ -472,8 +472,8 @@ class AppStoreServerAPIClient:
 
     def _make_request(self, path: str, method: str, queryParameters: Dict[str, Union[str, List[str]]], body, destination_class: Type[T]) -> T:
         url = self._base_url + path
-        c = _get_cattrs_converter(type(body)) if body != None else None
-        json = c.unstructure(body) if body != None else None
+        c = _get_cattrs_converter(type(body)) if body is not None else None
+        json = c.unstructure(body) if body is not None else None
         headers = {
             'User-Agent': "app-store-server-library/python/1.1.0",
             'Authorization': 'Bearer ' + self._generate_token(),
@@ -481,8 +481,8 @@ class AppStoreServerAPIClient:
         }
         
         response = self._execute_request(method, url, queryParameters, headers, json)
-        if response.status_code >= 200 and response.status_code < 300:
-            if destination_class == None:
+        if 200 <= response.status_code < 300:
+            if destination_class is None:
                 return
             c = _get_cattrs_converter(destination_class)
             response_body = response.json()
@@ -536,7 +536,7 @@ class AppStoreServerAPIClient:
         :throws APIException: If a response was returned indicating the request could not be processed
         """
         queryParameters: Dict[str, List[str]] = dict()
-        if status != None:
+        if status is not None:
             queryParameters["status"] = [s.value for s in status]
         
         return self._make_request("/inApps/v1/subscriptions/" + transaction_id, "GET", queryParameters, None, StatusResponse)
@@ -553,7 +553,7 @@ class AppStoreServerAPIClient:
         """
 
         queryParameters: Dict[str, List[str]] = dict()
-        if revision != None:
+        if revision is not None:
             queryParameters["revision"] = [revision]
         
         return self._make_request("/inApps/v2/refund/lookup/" + transaction_id, "GET", queryParameters, None, RefundHistoryResponse)
@@ -592,7 +592,7 @@ class AppStoreServerAPIClient:
         :throws APIException: If a response was returned indicating the request could not be processed
         """
         queryParameters: Dict[str, List[str]] = dict()
-        if pagination_token != None:
+        if pagination_token is not None:
             queryParameters["paginationToken"] = [pagination_token]
         
         return self._make_request("/inApps/v1/notifications/history", "POST", queryParameters, notification_history_request, NotificationHistoryResponse)
@@ -608,31 +608,31 @@ class AppStoreServerAPIClient:
         :throws APIException: If a response was returned indicating the request could not be processed
         """
         queryParameters: Dict[str, List[str]] = dict()
-        if revision != None:
+        if revision is not None:
             queryParameters["revision"] = [revision]
         
-        if transaction_history_request.startDate != None:
+        if transaction_history_request.startDate is not None:
             queryParameters["startDate"] = [str(transaction_history_request.startDate)]
         
-        if transaction_history_request.endDate != None:
+        if transaction_history_request.endDate is not None:
             queryParameters["endDate"] = [str(transaction_history_request.endDate)]
         
-        if transaction_history_request.productIds != None:
+        if transaction_history_request.productIds is not None:
             queryParameters["productId"] = transaction_history_request.productIds
         
-        if transaction_history_request.productTypes != None:
+        if transaction_history_request.productTypes is not None:
             queryParameters["productType"] = [product_type.value for product_type in transaction_history_request.productTypes]
         
-        if transaction_history_request.sort != None:
+        if transaction_history_request.sort is not None:
             queryParameters["sort"] = [transaction_history_request.sort.value]
         
-        if transaction_history_request.subscriptionGroupIdentifiers != None:
+        if transaction_history_request.subscriptionGroupIdentifiers is not None:
             queryParameters["subscriptionGroupIdentifier"] = transaction_history_request.subscriptionGroupIdentifiers
         
-        if transaction_history_request.inAppOwnershipType != None:
+        if transaction_history_request.inAppOwnershipType is not None:
             queryParameters["inAppOwnershipType"] = [transaction_history_request.inAppOwnershipType.value]
         
-        if transaction_history_request.revoked != None:
+        if transaction_history_request.revoked is not None:
             queryParameters["revoked"] = [str(transaction_history_request.revoked)]
         
         return self._make_request("/inApps/v1/history/" + transaction_id, "GET", queryParameters, None, HistoryResponse)

--- a/appstoreserverlibrary/api_client.py
+++ b/appstoreserverlibrary/api_client.py
@@ -547,7 +547,7 @@ class AppStoreServerAPIClient:
         https://developer.apple.com/documentation/appstoreserverapi/get_refund_history
 
         :param transaction_id: The identifier of a transaction that belongs to the customer, and which may be an original transaction identifier.
-        :param revision:              A token you provide to get the next set of up to 20 transactions. All responses include a revision token. Use the revision token from the previous RefundHistoryResponse.
+        :param revision: A token you provide to get the next set of up to 20 transactions. All responses include a revision token. Use the revision token from the previous RefundHistoryResponse.
         :return: A response that contains status information for all of a customer's auto-renewable subscriptions in your app.
         :throws APIException: If a response was returned indicating the request could not be processed
         """
@@ -564,7 +564,7 @@ class AppStoreServerAPIClient:
         https://developer.apple.com/documentation/appstoreserverapi/get_status_of_subscription_renewal_date_extensions
 
         :param request_identifier: The UUID that represents your request to the Extend Subscription Renewal Dates for All Active Subscribers endpoint.
-        :param product_id:         The product identifier of the auto-renewable subscription that you request a renewal-date extension for.
+        :param product_id: The product identifier of the auto-renewable subscription that you request a renewal-date extension for.
         :return: A response that indicates the current status of a request to extend the subscription renewal date to all eligible subscribers.
         :throws APIException: If a response was returned indicating the request could not be processed
         """
@@ -603,7 +603,8 @@ class AppStoreServerAPIClient:
         https://developer.apple.com/documentation/appstoreserverapi/get_transaction_history
 
         :param transaction_id: The identifier of a transaction that belongs to the customer, and which may be an original transaction identifier.
-        :param revision:              A token you provide to get the next set of up to 20 transactions. All responses include a revision token. Note: For requests that use the revision token, include the same query parameters from the initial request. Use the revision token from the previous HistoryResponse.
+        :param revision: A token you provide to get the next set of up to 20 transactions. All responses include a revision token. Note: For requests that use the revision token, include the same query parameters from the initial request. Use the revision token from the previous HistoryResponse.
+        :param transaction_history_request: The request parameters that includes the startDate,endDate,productIds,productTypes and optional query constraints.
         :return: A response that contains the customer's transaction history for an app.
         :throws APIException: If a response was returned indicating the request could not be processed
         """

--- a/appstoreserverlibrary/models/ExtendRenewalDateRequest.py
+++ b/appstoreserverlibrary/models/ExtendRenewalDateRequest.py
@@ -17,9 +17,9 @@ class ExtendRenewalDateRequest:
     extendByDays: Optional[int] = attr.ib(default=None)
     """
     The number of days to extend the subscription renewal date.
-    The number of days is a number from 1 to 90.
 
     https://developer.apple.com/documentation/appstoreserverapi/extendbydays
+    maximum: 90
     """
 
     extendReasonCode: Optional[ExtendReasonCode] = attr.ib(default=None)

--- a/appstoreserverlibrary/models/ExtendRenewalDateRequest.py
+++ b/appstoreserverlibrary/models/ExtendRenewalDateRequest.py
@@ -17,9 +17,9 @@ class ExtendRenewalDateRequest:
     extendByDays: Optional[int] = attr.ib(default=None)
     """
     The number of days to extend the subscription renewal date.
-    
+    The number of days is a number from 1 to 90.
+
     https://developer.apple.com/documentation/appstoreserverapi/extendbydays
-    maximum: 90
     """
 
     extendReasonCode: Optional[ExtendReasonCode] = attr.ib(default=None)

--- a/appstoreserverlibrary/models/JWSTransactionDecodedPayload.py
+++ b/appstoreserverlibrary/models/JWSTransactionDecodedPayload.py
@@ -203,7 +203,7 @@ class JWSTransactionDecodedPayload(AttrsRawValueAware):
 
     transactionReason: Optional[TransactionReason] = TransactionReason.create_main_attr('rawTransactionReason')
     """
-    The reason for the purchase transaction, which indicates whether it's a customer's purchase or a renewal for an auto-renewable subscription that the system initates.
+    The reason for the purchase transaction, which indicates whether it's a customer's purchase or a renewal for an auto-renewable subscription that the system initiates.
     
     https://developer.apple.com/documentation/appstoreserverapi/transactionreason
     """
@@ -222,7 +222,7 @@ class JWSTransactionDecodedPayload(AttrsRawValueAware):
 
     price: Optional[int] = attr.ib(default=None)
     """
-    The price, in milliunits, of the in-app purchase or subscription offer that you configured in App Store Connect.
+    The price, in milli units, of the in-app purchase or subscription offer that you configured in App Store Connect.
     
     https://developer.apple.com/documentation/appstoreserverapi/price
     """

--- a/appstoreserverlibrary/models/JWSTransactionDecodedPayload.py
+++ b/appstoreserverlibrary/models/JWSTransactionDecodedPayload.py
@@ -222,7 +222,7 @@ class JWSTransactionDecodedPayload(AttrsRawValueAware):
 
     price: Optional[int] = attr.ib(default=None)
     """
-    The price, in milli units, of the in-app purchase or subscription offer that you configured in App Store Connect.
+    The price, in milliunits, of the in-app purchase or subscription offer that you configured in App Store Connect.
     
     https://developer.apple.com/documentation/appstoreserverapi/price
     """

--- a/appstoreserverlibrary/models/NotificationHistoryResponse.py
+++ b/appstoreserverlibrary/models/NotificationHistoryResponse.py
@@ -32,4 +32,5 @@ class NotificationHistoryResponse:
     """
     An array of App Store server notification history records.
     
+    https://developer.apple.com/documentation/appstoreserverapi/notificationhistoryresponseitem
     """

--- a/appstoreserverlibrary/models/NotificationTypeV2.py
+++ b/appstoreserverlibrary/models/NotificationTypeV2.py
@@ -8,7 +8,7 @@ class NotificationTypeV2(str, Enum, metaclass=AppStoreServerLibraryEnumMeta):
     """
     A notification type value that App Store Server Notifications V2 uses.
     
-    https://developer.apple.com/documentation/appstoreserverapi/notificationtype
+    https://developer.apple.com/documentation/appstoreservernotifications/notificationtype
     """
     SUBSCRIBED = "SUBSCRIBED"
     DID_CHANGE_RENEWAL_PREF = "DID_CHANGE_RENEWAL_PREF"

--- a/appstoreserverlibrary/models/OrderLookupResponse.py
+++ b/appstoreserverlibrary/models/OrderLookupResponse.py
@@ -30,4 +30,6 @@ class OrderLookupResponse(AttrsRawValueAware):
     signedTransactions: Optional[List[str]] = attr.ib(default=None)
     """
     An array of in-app purchase transactions that are part of order, signed by Apple, in JSON Web Signature format.
+    
+    https://developer.apple.com/documentation/appstoreserverapi/jwstransaction
     """

--- a/appstoreserverlibrary/models/RefundHistoryResponse.py
+++ b/appstoreserverlibrary/models/RefundHistoryResponse.py
@@ -15,6 +15,8 @@ class RefundHistoryResponse:
     signedTransactions: Optional[List[str]] = attr.ib(default=None)
     """
     A list of up to 20 JWS transactions, or an empty array if the customer hasn't received any refunds in your app. The transactions are sorted in ascending order by revocationDate.
+    
+    https://developer.apple.com/documentation/appstoreserverapi/jwstransaction
     """
 
     revision: Optional[str] = attr.ib(default=None)

--- a/appstoreserverlibrary/models/StatusResponse.py
+++ b/appstoreserverlibrary/models/StatusResponse.py
@@ -46,4 +46,5 @@ class StatusResponse(AttrsRawValueAware):
     """
     An array of information for auto-renewable subscriptions, including App Store-signed transaction information and App Store-signed renewal information.
     
+    https://developer.apple.com/documentation/appstoreserverapi/subscriptiongroupidentifieritem
     """

--- a/appstoreserverlibrary/models/SubscriptionGroupIdentifierItem.py
+++ b/appstoreserverlibrary/models/SubscriptionGroupIdentifierItem.py
@@ -24,4 +24,6 @@ class SubscriptionGroupIdentifierItem:
     lastTransactions: Optional[List[LastTransactionsItem]] = attr.ib(default=None)
     """
     An array of the most recent App Store-signed transaction information and App Store-signed renewal information for all auto-renewable subscriptions in the subscription group.
+    
+    https://developer.apple.com/documentation/appstoreserverapi/lasttransactionsitem
     """

--- a/appstoreserverlibrary/models/Subtype.py
+++ b/appstoreserverlibrary/models/Subtype.py
@@ -6,7 +6,7 @@ from .LibraryUtility import AppStoreServerLibraryEnumMeta
 
 class Subtype(str, Enum, metaclass=AppStoreServerLibraryEnumMeta):
     """
-    A notification subtype value that App Store Server Notifications 2 uses.
+    A notification subtype value that App Store Server Notifications V2 uses.
     
     https://developer.apple.com/documentation/appstoreserverapi/notificationsubtype
     """

--- a/appstoreserverlibrary/models/Subtype.py
+++ b/appstoreserverlibrary/models/Subtype.py
@@ -8,7 +8,7 @@ class Subtype(str, Enum, metaclass=AppStoreServerLibraryEnumMeta):
     """
     A notification subtype value that App Store Server Notifications V2 uses.
     
-    https://developer.apple.com/documentation/appstoreserverapi/notificationsubtype
+    https://developer.apple.com/documentation/appstoreservernotifications/subtype
     """
     INITIAL_BUY = "INITIAL_BUY"
     RESUBSCRIBE = "RESUBSCRIBE"

--- a/appstoreserverlibrary/models/TransactionHistoryRequest.py
+++ b/appstoreserverlibrary/models/TransactionHistoryRequest.py
@@ -66,5 +66,5 @@ class TransactionHistoryRequest:
    
     revoked: Optional[bool] = attr.ib(default=None)
     """
-    An optional Boolean value that indicates whether the response includes only revoked transactions when the value is true, or contains only non-revoked transactions when the value is false. By default, the request doesn't include this parameter.
+    An optional Boolean value that indicates whether the response includes only revoked transactions when the value is true, or contains only nonrevoked transactions when the value is false. By default, the request doesn't include this parameter.
     """

--- a/appstoreserverlibrary/models/TransactionHistoryRequest.py
+++ b/appstoreserverlibrary/models/TransactionHistoryRequest.py
@@ -66,5 +66,5 @@ class TransactionHistoryRequest:
    
     revoked: Optional[bool] = attr.ib(default=None)
     """
-    An optional Boolean value that indicates whether the response includes only revoked transactions when the value is true, or contains only nonrevoked transactions when the value is false. By default, the request doesn't include this parameter.
+    An optional Boolean value that indicates whether the response includes only revoked transactions when the value is true, or contains only non-revoked transactions when the value is false. By default, the request doesn't include this parameter.
     """

--- a/tests/test_decoded_payloads.py
+++ b/tests/test_decoded_payloads.py
@@ -107,7 +107,7 @@ class DecodedPayloads(unittest.TestCase):
         self.assertEqual(1698148800000, renewal_info.recentSubscriptionStartDate)
         self.assertEqual(1698148850000, renewal_info.renewalDate)
 
-    def test_notificaiton_decoding(self):
+    def test_notification_decoding(self):
         signed_notification = create_signed_data_from_json('tests/resources/models/signedNotification.json')
         
         signed_data_verifier = get_default_signed_data_verifier()


### PR DESCRIPTION
1. Use is instead of == to check if a variable is None.
2. Method parameter annotation modification.
3. apple documentation link updates and additions.
4. word typo.