### PR TITLE
fix: update the offer type to the correct type

### DIFF
--- a/appstoreserverlibrary/models/JWSTransactionDecodedPayload.py
+++ b/appstoreserverlibrary/models/JWSTransactionDecodedPayload.py
@@ -156,7 +156,7 @@ class JWSTransactionDecodedPayload(AttrsRawValueAware):
     https://developer.apple.com/documentation/appstoreserverapi/isupgraded
     """
 
-    offerType: Optional[OfferType] = RevocationReason.create_main_attr('rawOfferType')
+    offerType: Optional[OfferType] = OfferType.create_main_attr('rawOfferType')
     """
     A value that represents the promotional offer type.
     


### PR DESCRIPTION
I've noticed that the offer type definition in the JWSTransactionDecodedPayload class is incorrect. I've made the necessary corrections. Thank you!