### PR TITLE
Fix use of deprecated datetime.utcnow() function

### DIFF
--- a/appstoreserverlibrary/api_client.py
+++ b/appstoreserverlibrary/api_client.py
@@ -466,7 +466,7 @@ class AppStoreServerAPIClient:
         self._bundle_id = bundle_id
 
     def _generate_token(self) -> str:
-        future_time = datetime.datetime.utcnow() + datetime.timedelta(minutes=5)
+        future_time = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(minutes=5)
         return jwt.encode(
             {
                 "bid": self._bundle_id,


### PR DESCRIPTION
Hi! When using this library with Python 3.12, you get a deprecation warning. Luckily it's easily fixed.

The warning:
```
  /usr/local/lib/python3.12/site-packages/appstoreserverlibrary/api_client.py:469: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    future_time = datetime.datetime.utcnow() + datetime.timedelta(minutes=5)
```

You can see that warning when running the tests in this repository with a sufficiently new Python (`python3 -m unittest`). Luckily the replacement is easy. I've used `datetime.timezone.utc` instead of `datetime.UTC` because that alias was only introduced in 3.11.