### PR TITLE
Throw ValueError if environment not one of the supported values

### DIFF
--- a/appstoreserverlibrary/api_client.py
+++ b/appstoreserverlibrary/api_client.py
@@ -466,8 +466,10 @@ class BaseAppStoreServerAPIClient:
             self._base_url = "https://api.storekit.itunes.apple.com"
         elif environment == Environment.LOCAL_TESTING:
             self._base_url = "https://local-testing-base-url"
-        else:
+        elif environment == Environment.SANDBOX:
             self._base_url = "https://api.storekit-sandbox.itunes.apple.com"
+        else:
+            raise ValueError("Invalid environment provided")
         self._signing_key = serialization.load_pem_private_key(signing_key, password=None, backend=default_backend())
         self._key_id = key_id
         self._issuer_id = issuer_id


### PR DESCRIPTION
Python does not enforce typing, meaning invalid types are possible