### PR TITLE
refactor library utility more pythonic

### DIFF
--- a/appstoreserverlibrary/models/LibraryUtility.py
+++ b/appstoreserverlibrary/models/LibraryUtility.py
@@ -20,8 +20,8 @@ class AppStoreServerLibraryEnumMeta(EnumMeta):
             c(val)
         except ValueError:
             return False
-        return True  
-    
+        return True
+
     def create_main_attr(c, raw_field_name: str) -> Any:
         def value_set(self, _: Attribute, value: c):
             newValue = value.value if value is not None else None
@@ -42,15 +42,14 @@ class AttrsRawValueAware:
     def __attrs_post_init__(self):
         attr_fields: List[Attribute] = fields(type(self))
         for attribute in attr_fields:
-            if metadata_type_key not in attribute.metadata or attribute.metadata[metadata_type_key] != 'raw':
+            if attribute.metadata.get(metadata_type_key) != 'raw':
                 continue
-            field: str = attribute.metadata.get(metadata_key)
-            rawField = 'raw' + field[0].upper() + field[1:]
-            rawValue = getattr(self, rawField)
-            value = getattr(self, field)
-            if rawValue is not None:
-                setattr(self, rawField, rawValue)
-            elif value is not None:
+            field: str = attribute.metadata[metadata_key]
+            raw_field = f'raw{field[0].upper()}{field[1:]}'
+
+            if (raw_value := getattr(self, raw_field)) is not None:
+                setattr(self, raw_field, raw_value)
+            elif (value := getattr(self, field)) is not None:
                 setattr(self, field, value)
 
 
@@ -60,12 +59,11 @@ def _get_cattrs_converter(destination_class: Type[T]) -> cattrs.Converter:
     attributes: List[Attribute] = fields(destination_class)
     cattrs_overrides = {}
     for attribute in attributes:
-        if metadata_type_key in attribute.metadata:
+        if attribute.metadata.get(metadata_type_key) == 'raw':
             matching_name: str = attribute.metadata[metadata_key]
-            if attribute.metadata[metadata_type_key] == 'raw':
-                cattrs_overrides[matching_name] = override(omit=True)
-                raw_field = 'raw' + matching_name[0].upper() + matching_name[1:]
-                cattrs_overrides[raw_field] = override(rename=matching_name)
+            cattrs_overrides[matching_name] = override(omit=True)
+            raw_field = f'raw{matching_name[0].upper()}{matching_name[1:]}'
+            cattrs_overrides[raw_field] = override(rename=matching_name)
     c.register_structure_hook_factory(has, lambda cl: make_dict_structure_fn(cl, c, **cattrs_overrides))
     c.register_unstructure_hook_factory(has, lambda cl: make_dict_unstructure_fn(cl, c, **cattrs_overrides))
     return c


### PR DESCRIPTION
- use .get  instead of `in` and `[]`
- use f-strings (since we support only 3.8+)
- use walrus operator (3.8+)