### PR TITLE
Fix SyntaxWarning in regex pattern string

### DIFF
--- a/appstoreserverlibrary/receipt_utility.py
+++ b/appstoreserverlibrary/receipt_utility.py
@@ -92,10 +92,10 @@ class ReceiptUtility:
         :return: A transaction id, or null if no transactionId is found in the receipt
         """
         decoded_top_level = base64.b64decode(transaction_receipt).decode('utf-8')
-        matching_result = re.search('"purchase-info"\s+=\s+"([a-zA-Z0-9+/=]+)";', decoded_top_level)
+        matching_result = re.search(r'"purchase-info"\s+=\s+"([a-zA-Z0-9+/=]+)";', decoded_top_level)
         if matching_result:
             decoded_inner_level = base64.b64decode(matching_result.group(1)).decode('utf-8')
-            inner_matching_result = re.search('"transaction-id"\s+=\s+"([a-zA-Z0-9+/=]+)";', decoded_inner_level)
+            inner_matching_result = re.search(r'"transaction-id"\s+=\s+"([a-zA-Z0-9+/=]+)";', decoded_inner_level)
             if inner_matching_result:
                 return inner_matching_result.group(1)
         return None


### PR DESCRIPTION
In Python 3.12, invalid escape sequence (such as `\s`) in normal string emits SyntaxWarning.
```
/Users/krepe90/github/krepe90/app-store-server-library-python/appstoreserverlibrary/receipt_utility.py:95: SyntaxWarning: invalid escape sequence '\s'
  matching_result = re.search('"purchase-info"\s+=\s+"([a-zA-Z0-9+/=]+)";', decoded_top_level)
/Users/krepe90/github/krepe90/app-store-server-library-python/appstoreserverlibrary/receipt_utility.py:98: SyntaxWarning: invalid escape sequence '\s'
  inner_matching_result = re.search('"transaction-id"\s+=\s+"([a-zA-Z0-9+/=]+)";', decoded_inner_level)
```
So I changed the regex pattern strings to use raw string literals (prefixing the string with `r`).

See also: https://docs.python.org/3/whatsnew/3.12.html#other-language-changes