### PR TITLE
Upload/List/Delete Retention Messages

### DIFF
--- a/appstoreserverlibrary/models/GetMessageListResponse.py
+++ b/appstoreserverlibrary/models/GetMessageListResponse.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2023 Apple Inc. Licensed under MIT License.
+
+from typing import Optional, List
+from attr import define
+import attr
+from .GetMessageListResponseItem import GetMessageListResponseItem
+
+@define
+class GetMessageListResponse:
+    """
+    A response that contains status information for all messages.
+
+    https://developer.apple.com/documentation/retentionmessaging/getmessagelistresponse
+    """
+
+    messageIdentifiers: Optional[List[GetMessageListResponseItem]] = attr.ib(default=None)
+    """
+    An array of all message identifiers and their message states.
+
+    https://developer.apple.com/documentation/retentionmessaging/getmessagelistresponseitem
+    """

--- a/appstoreserverlibrary/models/GetMessageListResponseItem.py
+++ b/appstoreserverlibrary/models/GetMessageListResponseItem.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2023 Apple Inc. Licensed under MIT License.
+
+from typing import Optional
+from attr import define
+import attr
+from .RetentionMessageState import RetentionMessageState
+from .LibraryUtility import AttrsRawValueAware
+
+@define
+class GetMessageListResponseItem(AttrsRawValueAware):
+    """
+    A message identifier and status information for a message.
+
+    https://developer.apple.com/documentation/retentionmessaging/getmessagelistresponseitem
+    """
+
+    messageIdentifier: Optional[str] = attr.ib(default=None)
+    """
+    The identifier of the message.
+
+    https://developer.apple.com/documentation/retentionmessaging/messageidentifier
+    """
+
+    messageState: Optional[RetentionMessageState] = RetentionMessageState.create_main_attr('rawMessageState')
+    """
+    The current state of the message.
+
+    https://developer.apple.com/documentation/retentionmessaging/messagestate
+    """
+
+    rawMessageState: Optional[str] = RetentionMessageState.create_raw_attr('messageState')
+    """
+    See messageState
+    """

--- a/appstoreserverlibrary/models/RetentionMessageState.py
+++ b/appstoreserverlibrary/models/RetentionMessageState.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2023 Apple Inc. Licensed under MIT License.
+
+from enum import Enum
+from .LibraryUtility import AppStoreServerLibraryEnumMeta
+
+class RetentionMessageState(Enum, metaclass=AppStoreServerLibraryEnumMeta):
+    """
+    The approval state of the message.
+
+    https://developer.apple.com/documentation/retentionmessaging/messagestate
+    """
+
+    PENDING = "PENDING"
+    """
+    The message is awaiting approval.
+    """
+
+    APPROVED = "APPROVED"
+    """
+    The message is approved.
+    """
+
+    REJECTED = "REJECTED"
+    """
+    The message is rejected.
+    """

--- a/appstoreserverlibrary/models/UploadMessageImage.py
+++ b/appstoreserverlibrary/models/UploadMessageImage.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2023 Apple Inc. Licensed under MIT License.
+
+from typing import Optional
+from attr import define
+import attr
+
+@define
+class UploadMessageImage:
+    """
+    The definition of an image with its alternative text.
+
+    https://developer.apple.com/documentation/retentionmessaging/uploadmessageimage
+    """
+
+    imageIdentifier: Optional[str] = attr.ib(default=None)
+    """
+    The unique identifier of an image.
+
+    https://developer.apple.com/documentation/retentionmessaging/imageidentifier
+    """
+
+    altText: Optional[str] = attr.ib(default=None)
+    """
+    The alternative text you provide for the corresponding image.
+    Maximum length: 150
+
+    https://developer.apple.com/documentation/retentionmessaging/alttext
+    """

--- a/appstoreserverlibrary/models/UploadMessageRequestBody.py
+++ b/appstoreserverlibrary/models/UploadMessageRequestBody.py
@@ -1,0 +1,37 @@
+# Copyright (c) 2023 Apple Inc. Licensed under MIT License.
+
+from typing import Optional
+from attr import define
+import attr
+from .UploadMessageImage import UploadMessageImage
+
+@define
+class UploadMessageRequestBody:
+    """
+    The request body for uploading a message, which includes the message text and an optional image reference.
+
+    https://developer.apple.com/documentation/retentionmessaging/uploadmessagerequestbody
+    """
+
+    header: Optional[str] = attr.ib(default=None)
+    """
+    The header text of the retention message that the system displays to customers.
+    Maximum length: 66
+
+    https://developer.apple.com/documentation/retentionmessaging/header
+    """
+
+    body: Optional[str] = attr.ib(default=None)
+    """
+    The body text of the retention message that the system displays to customers.
+    Maximum length: 144
+
+    https://developer.apple.com/documentation/retentionmessaging/body
+    """
+
+    image: Optional[UploadMessageImage] = attr.ib(default=None)
+    """
+    The optional image identifier and its alternative text to appear as part of a text-based message with an image.
+
+    https://developer.apple.com/documentation/retentionmessaging/uploadmessageimage
+    """

--- a/tests/resources/models/getRetentionMessageListResponse.json
+++ b/tests/resources/models/getRetentionMessageListResponse.json
@@ -1,0 +1,16 @@
+{
+  "messageIdentifiers": [
+    {
+      "messageIdentifier": "test-message-1",
+      "messageState": "APPROVED"
+    },
+    {
+      "messageIdentifier": "test-message-2",
+      "messageState": "PENDING"
+    },
+    {
+      "messageIdentifier": "test-message-3",
+      "messageState": "REJECTED"
+    }
+  ]
+}

--- a/tests/resources/models/retentionMessageAlreadyExistsError.json
+++ b/tests/resources/models/retentionMessageAlreadyExistsError.json
@@ -1,0 +1,4 @@
+{
+  "errorCode": 4090001,
+  "errorMessage": "An error that indicates the message identifier already exists."
+}

--- a/tests/resources/models/retentionMessageHeaderTooLongError.json
+++ b/tests/resources/models/retentionMessageHeaderTooLongError.json
@@ -1,0 +1,4 @@
+{
+  "errorCode": 4000101,
+  "errorMessage": "An error that indicates the message header exceeds 66 characters."
+}

--- a/tests/resources/models/retentionMessageNotFoundError.json
+++ b/tests/resources/models/retentionMessageNotFoundError.json
@@ -1,0 +1,4 @@
+{
+  "errorCode": 4040001,
+  "errorMessage": "An error that indicates the specified message was not found."
+}

--- a/tests/test_api_client_async.py
+++ b/tests/test_api_client_async.py
@@ -40,6 +40,9 @@ from appstoreserverlibrary.models.TransactionReason import TransactionReason
 from appstoreserverlibrary.models.Type import Type
 from appstoreserverlibrary.models.UpdateAppAccountTokenRequest import UpdateAppAccountTokenRequest
 from appstoreserverlibrary.models.UserStatus import UserStatus
+from appstoreserverlibrary.models.UploadMessageRequestBody import UploadMessageRequestBody
+from appstoreserverlibrary.models.UploadMessageImage import UploadMessageImage
+from appstoreserverlibrary.models.RetentionMessageState import RetentionMessageState
 
 from tests.util import decode_json_from_signed_date, read_data_from_binary_file, read_data_from_file
 
@@ -594,4 +597,126 @@ class DecodedPayloads(unittest.IsolatedAsyncioTestCase):
     def get_client_with_body_from_file(self, path: str, expected_method: str, expected_url: str, expected_params: Dict[str, Union[str, List[str]]], expected_json: Dict[str, Any], status_code: int = 200):
         body = read_data_from_binary_file(path)
         return self.get_client_with_body(body, expected_method, expected_url, expected_params, expected_json, status_code)
+
+    async def test_upload_retention_message(self):
+        client = self.get_client_with_body(b'',
+                                           'PUT',
+                                           'https://local-testing-base-url/inApps/v1/messaging/message/test-message-id',
+                                           {},
+                                           {'header': 'Test Header', 'body': 'Test message body', 'image': None})
+
+        retention_message_request = UploadMessageRequestBody(
+            header='Test Header',
+            body='Test message body'
+        )
+
+        # Should not raise exception for successful upload
+        await client.upload_retention_message('test-message-id', retention_message_request)
+
+    async def test_upload_retention_message_with_image(self):
+        client = self.get_client_with_body(b'',
+                                           'PUT',
+                                           'https://local-testing-base-url/inApps/v1/messaging/message/test-message-id',
+                                           {},
+                                           {
+                                               'header': 'Test Header',
+                                               'body': 'Test message body',
+                                               'image': {
+                                                   'imageIdentifier': 'test-image-id',
+                                                   'altText': 'Test image'
+                                               }
+                                           })
+
+        retention_message_request = UploadMessageRequestBody(
+            header='Test Header',
+            body='Test message body',
+            image=UploadMessageImage(
+                imageIdentifier='test-image-id',
+                altText='Test image'
+            )
+        )
+
+        # Should not raise exception for successful upload
+        await client.upload_retention_message('test-message-id', retention_message_request)
+
+    async def test_get_retention_message_list(self):
+        client = self.get_client_with_body_from_file('tests/resources/models/getRetentionMessageListResponse.json',
+                                           'GET',
+                                           'https://local-testing-base-url/inApps/v1/messaging/message/list',
+                                           {},
+                                           None)
+
+        response = await client.get_retention_message_list()
+
+        self.assertIsNotNone(response)
+        self.assertIsNotNone(response.messageIdentifiers)
+        self.assertEqual(3, len(response.messageIdentifiers))
+
+        # Check first message
+        message1 = response.messageIdentifiers[0]
+        self.assertEqual('test-message-1', message1.messageIdentifier)
+        self.assertEqual(RetentionMessageState.APPROVED, message1.messageState)
+
+        # Check second message
+        message2 = response.messageIdentifiers[1]
+        self.assertEqual('test-message-2', message2.messageIdentifier)
+        self.assertEqual(RetentionMessageState.PENDING, message2.messageState)
+
+        # Check third message
+        message3 = response.messageIdentifiers[2]
+        self.assertEqual('test-message-3', message3.messageIdentifier)
+        self.assertEqual(RetentionMessageState.REJECTED, message3.messageState)
+
+    async def test_delete_retention_message(self):
+        client = self.get_client_with_body(b'',
+                                           'DELETE',
+                                           'https://local-testing-base-url/inApps/v1/messaging/message/test-message-id',
+                                           {},
+                                           None)
+
+        # Should not raise exception for successful deletion
+        await client.delete_retention_message('test-message-id')
+
+    async def test_upload_retention_message_already_exists_error(self):
+        client = self.get_client_with_body_from_file('tests/resources/models/retentionMessageAlreadyExistsError.json',
+                                                     'PUT',
+                                                     'https://local-testing-base-url/inApps/v1/messaging/message/test-message-id',
+                                                     {},
+                                                     {'header': 'Test Header', 'body': 'Test message body', 'image': None},
+                                                     409)
+
+        retention_message_request = UploadMessageRequestBody(
+            header='Test Header',
+            body='Test message body'
+        )
+
+        try:
+            await client.upload_retention_message('test-message-id', retention_message_request)
+        except APIException as e:
+            self.assertEqual(409, e.http_status_code)
+            self.assertEqual(4090001, e.raw_api_error)
+            self.assertEqual(APIError.MESSAGE_ALREADY_EXISTS_ERROR, e.api_error)
+            self.assertEqual("An error that indicates the message identifier already exists.", e.error_message)
+            return
+
+        self.assertFalse(True)
+
+    async def test_delete_retention_message_not_found_error(self):
+        client = self.get_client_with_body_from_file('tests/resources/models/retentionMessageNotFoundError.json',
+                                                     'DELETE',
+                                                     'https://local-testing-base-url/inApps/v1/messaging/message/nonexistent-message-id',
+                                                     {},
+                                                     None,
+                                                     404)
+
+        try:
+            await client.delete_retention_message('nonexistent-message-id')
+        except APIException as e:
+            self.assertEqual(404, e.http_status_code)
+            self.assertEqual(4040001, e.raw_api_error)
+            self.assertEqual(APIError.MESSAGE_NOT_FOUND_ERROR, e.api_error)
+            self.assertEqual("An error that indicates the specified message was not found.", e.error_message)
+            return
+
+        self.assertFalse(True)
 


### PR DESCRIPTION
Hi! This PR adds initial support for the [Retention Messaging API](https://developer.apple.com/documentation/RetentionMessaging) in reference to https://github.com/apple/app-store-server-library-python/issues/152 and `FB20273865`

This focuses on adding basic support for uploading/listing/deleting messages. Image uploads and default message support are out of scope for this PR. A separate PR is planned to add JWS parsing support for `RealtimeRequestBody`.

Open to feedback here, please let me know if there is anything I am missing, or if you'd like to see this revised in any way.

Cheers!