### PR TITLE
Add serializer and models for RealtimeResponseBody

### DIFF
--- a/appstoreserverlibrary/models/AlternateProduct.py
+++ b/appstoreserverlibrary/models/AlternateProduct.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2023 Apple Inc. Licensed under MIT License.
+
+from typing import Optional
+from attr import define
+import attr
+
+@define
+class AlternateProduct:
+    """
+    A switch-plan message and product ID you provide in a real-time response to your Get Retention Message endpoint.
+
+    https://developer.apple.com/documentation/retentionmessaging/alternateproduct
+    """
+
+    messageIdentifier: Optional[str] = attr.ib(default=None)
+    """
+    The message identifier of the text to display in the switch-plan retention message.
+
+    The message identifier needs to refer to a message that doesn't include an image and that
+    has a messageState of APPROVED; otherwise, the retention message fails.
+
+    https://developer.apple.com/documentation/retentionmessaging/messageidentifier
+    """
+
+    productId: Optional[str] = attr.ib(default=None)
+    """
+    The product identifier of the subscription the retention message suggests for your customer to switch to.
+
+    Use the product identifier in DecodedRealtimeRequestBody to determine the customer's current subscription.
+    Choose an alternative subscription from the same subscription group.
+
+    https://developer.apple.com/documentation/retentionmessaging/productid
+    """

--- a/appstoreserverlibrary/models/Message.py
+++ b/appstoreserverlibrary/models/Message.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2023 Apple Inc. Licensed under MIT License.
+
+from typing import Optional
+from attr import define
+import attr
+
+@define
+class Message:
+    """
+    A message identifier you provide in a real-time response to your Get Retention Message endpoint.
+
+    https://developer.apple.com/documentation/retentionmessaging/message
+    """
+
+    messageIdentifier: Optional[str] = attr.ib(default=None)
+    """
+    The identifier of the message to display to the customer.
+
+    The message identifier needs to refer to a message that has a messageState of APPROVED;
+    otherwise, the retention message fails. If the message includes an image, the image also
+    needs to have an imageState of APPROVED.
+
+    For more information about setting up messages, see Upload Message.
+
+    https://developer.apple.com/documentation/retentionmessaging/messageidentifier
+    """

--- a/appstoreserverlibrary/models/PromotionalOffer.py
+++ b/appstoreserverlibrary/models/PromotionalOffer.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2023 Apple Inc. Licensed under MIT License.
+
+from typing import Optional
+from attr import define
+import attr
+from .PromotionalOfferSignatureV1 import PromotionalOfferSignatureV1
+
+@define
+class PromotionalOffer:
+    """
+    A promotional offer and message you provide in a real-time response to your Get Retention Message endpoint.
+
+    https://developer.apple.com/documentation/retentionmessaging/promotionaloffer
+    """
+
+    messageIdentifier: Optional[str] = attr.ib(default=None)
+    """
+    The identifier of the message to display to the customer, along with the promotional offer.
+
+    The message identifier needs to refer to a message that doesn't have an image, and that has
+    a messageState of APPROVED; otherwise, the retention message fails.
+
+    https://developer.apple.com/documentation/retentionmessaging/messageidentifier
+    """
+
+    promotionalOfferSignatureV2: Optional[str] = attr.ib(default=None)
+    """
+    The promotional offer signature in V2 format. This field is mutually exclusive with
+    promotionalOfferSignatureV1 field.
+
+    For new implementations, consider using this V2 signature, which is easier to generate.
+    To generate this signature, use the PromotionalOfferV2SignatureCreator class:
+
+    Example:
+        from appstoreserverlibrary.jws_signature_creator import PromotionalOfferV2SignatureCreator
+
+        creator = PromotionalOfferV2SignatureCreator(signing_key, key_id, issuer_id, bundle_id)
+        signature = creator.create_signature(
+            product_id="com.example.subscription",
+            offer_identifier="intro_offer",
+            transaction_id="optional_transaction_id"
+        )
+
+    https://developer.apple.com/documentation/retentionmessaging/promotionaloffersignaturev2
+    """
+
+    promotionalOfferSignatureV1: Optional[PromotionalOfferSignatureV1] = attr.ib(default=None)
+    """
+    The promotional offer signature in V1 format. This field is mutually exclusive with the
+    promotionalOfferSignatureV2 field.
+
+    To generate this signature, use the PromotionalOfferSignatureCreator class.
+    See PromotionalOfferSignatureV1 for implementation details.
+
+    https://developer.apple.com/documentation/retentionmessaging/promotionaloffersignaturev1
+    """

--- a/appstoreserverlibrary/models/PromotionalOfferSignatureV1.py
+++ b/appstoreserverlibrary/models/PromotionalOfferSignatureV1.py
@@ -1,0 +1,71 @@
+# Copyright (c) 2023 Apple Inc. Licensed under MIT License.
+
+from typing import Optional
+from attr import define
+import attr
+
+@define
+class PromotionalOfferSignatureV1:
+    """
+    The promotional offer signature you generate using an earlier signature version.
+
+    To generate this signature, use the PromotionalOfferSignatureCreator class:
+
+    Example:
+        from appstoreserverlibrary.promotional_offer import PromotionalOfferSignatureCreator
+        import uuid
+        import time
+
+        creator = PromotionalOfferSignatureCreator(signing_key, key_id, bundle_id)
+        signature = creator.create_signature(
+            product_identifier="com.example.subscription",
+            subscription_offer_id="intro_offer",
+            application_username="user123",
+            nonce=uuid.uuid4(),
+            timestamp=int(time.time() * 1000)
+        )
+
+    https://developer.apple.com/documentation/retentionmessaging/promotionaloffersignaturev1
+    """
+
+    encodedSignature: Optional[str] = attr.ib(default=None)
+    """
+    The Base64-encoded cryptographic signature you generate using the offer parameters.
+
+    https://developer.apple.com/documentation/retentionmessaging/encodedsignature
+    """
+
+    productId: Optional[str] = attr.ib(default=None)
+    """
+    The subscription's product identifier.
+
+    https://developer.apple.com/documentation/retentionmessaging/productid
+    """
+
+    nonce: Optional[str] = attr.ib(default=None)
+    """
+    A one-time-use UUID antireplay value you generate. Use lowercase.
+
+    https://developer.apple.com/documentation/retentionmessaging/nonce
+    """
+
+    offerId: Optional[str] = attr.ib(default=None)
+    """
+    The promotional offer's identifier.
+
+    https://developer.apple.com/documentation/retentionmessaging/offerid
+    """
+
+    timestamp: Optional[int] = attr.ib(default=None)
+    """
+    The UNIX time, in milliseconds, that you generate the signature.
+
+    https://developer.apple.com/documentation/retentionmessaging/timestamp
+    """
+
+    keyIdentifier: Optional[str] = attr.ib(default=None)
+    """
+    Your private key identifier from App Store Connect.
+
+    https://developer.apple.com/documentation/retentionmessaging/keyidentifier
+    """

--- a/appstoreserverlibrary/models/RealtimeResponseBody.py
+++ b/appstoreserverlibrary/models/RealtimeResponseBody.py
@@ -1,0 +1,61 @@
+# Copyright (c) 2023 Apple Inc. Licensed under MIT License.
+
+from typing import Optional, Dict, Any
+from attr import define
+import attr
+from .Message import Message
+from .AlternateProduct import AlternateProduct
+from .PromotionalOffer import PromotionalOffer
+
+@define
+class RealtimeResponseBody:
+    """
+    A response you provide to choose, in real time, a retention message the system displays to the customer.
+
+    Note: The fields in RealtimeResponseBody are mutually exclusive. Choose the type of retention message
+    to display, and respond using only the field that represents that message type.
+
+    https://developer.apple.com/documentation/retentionmessaging/realtimeresponsebody
+    """
+
+    message: Optional[Message] = attr.ib(default=None)
+    """
+    A retention message that's text-based and can include an optional image.
+    If you supply this field, don't include the other fields.
+
+    https://developer.apple.com/documentation/retentionmessaging/message
+    """
+
+    alternateProduct: Optional[AlternateProduct] = attr.ib(default=None)
+    """
+    A retention message with a switch-plan option.
+    If you supply this field, don't include the other fields.
+
+    https://developer.apple.com/documentation/retentionmessaging/alternateproduct
+    """
+
+    promotionalOffer: Optional[PromotionalOffer] = attr.ib(default=None)
+    """
+    A retention message that includes a promotional offer.
+    If you supply this field, don't include the other fields.
+
+    https://developer.apple.com/documentation/retentionmessaging/promotionaloffer
+    """
+
+    def to_json_dict(self) -> Dict[str, Any]:
+        """
+        Convert to a dictionary suitable for JSON serialization.
+        Omits None values to maintain mutual exclusivity of fields.
+
+        Example:
+            response = RealtimeResponseBody(
+                message=Message(messageIdentifier="msg123")
+            )
+            json_data = json.dumps(response.to_json_dict())
+            # Result: {"message": {"messageIdentifier": "msg123"}}
+
+        :return: Dictionary representation suitable for JSON encoding
+        """
+        from .LibraryUtility import _get_retention_response_converter
+        converter = _get_retention_response_converter()
+        return converter.unstructure(self)

--- a/tests/test_retention_response_serialization.py
+++ b/tests/test_retention_response_serialization.py
@@ -1,0 +1,145 @@
+# Copyright (c) 2023 Apple Inc. Licensed under MIT License.
+
+import unittest
+import json
+from appstoreserverlibrary.models.RealtimeResponseBody import RealtimeResponseBody
+from appstoreserverlibrary.models.Message import Message
+from appstoreserverlibrary.models.AlternateProduct import AlternateProduct
+from appstoreserverlibrary.models.PromotionalOffer import PromotionalOffer
+from appstoreserverlibrary.models.PromotionalOfferSignatureV1 import PromotionalOfferSignatureV1
+
+class RetentionResponseSerialization(unittest.TestCase):
+
+    def test_message_response_serialization(self):
+        response = RealtimeResponseBody(
+            message=Message(messageIdentifier="msg123")
+        )
+        json_dict = response.to_json_dict()
+
+        # Only message field should be present
+        self.assertEqual(json_dict, {"message": {"messageIdentifier": "msg123"}})
+        self.assertNotIn("alternateProduct", json_dict)
+        self.assertNotIn("promotionalOffer", json_dict)
+
+        # Verify JSON serialization works
+        json_str = json.dumps(json_dict)
+        self.assertEqual(json_str, '{"message": {"messageIdentifier": "msg123"}}')
+
+    def test_alternate_product_response_serialization(self):
+        response = RealtimeResponseBody(
+            alternateProduct=AlternateProduct(
+                messageIdentifier="msg456",
+                productId="com.example.premium"
+            )
+        )
+        json_dict = response.to_json_dict()
+
+        expected = {
+            "alternateProduct": {
+                "messageIdentifier": "msg456",
+                "productId": "com.example.premium"
+            }
+        }
+        self.assertEqual(json_dict, expected)
+        self.assertNotIn("message", json_dict)
+        self.assertNotIn("promotionalOffer", json_dict)
+
+    def test_promotional_offer_v2_response_serialization(self):
+        response = RealtimeResponseBody(
+            promotionalOffer=PromotionalOffer(
+                messageIdentifier="msg789",
+                promotionalOfferSignatureV2="eyJhbGciOiJFUzI1NiJ9.example.signature"
+            )
+        )
+        json_dict = response.to_json_dict()
+
+        expected = {
+            "promotionalOffer": {
+                "messageIdentifier": "msg789",
+                "promotionalOfferSignatureV2": "eyJhbGciOiJFUzI1NiJ9.example.signature"
+            }
+        }
+        self.assertEqual(json_dict, expected)
+        self.assertNotIn("message", json_dict)
+        self.assertNotIn("alternateProduct", json_dict)
+
+    def test_promotional_offer_v1_response_serialization(self):
+        v1_signature = PromotionalOfferSignatureV1(
+            encodedSignature="base64signature==",
+            productId="com.example.subscription",
+            nonce="550e8400-e29b-41d4-a716-446655440000",
+            offerId="intro_offer",
+            timestamp=1681314324000,
+            keyIdentifier="ABC123DEF4"
+        )
+
+        response = RealtimeResponseBody(
+            promotionalOffer=PromotionalOffer(
+                messageIdentifier="msg101112",
+                promotionalOfferSignatureV1=v1_signature
+            )
+        )
+        json_dict = response.to_json_dict()
+
+        expected = {
+            "promotionalOffer": {
+                "messageIdentifier": "msg101112",
+                "promotionalOfferSignatureV1": {
+                    "encodedSignature": "base64signature==",
+                    "productId": "com.example.subscription",
+                    "nonce": "550e8400-e29b-41d4-a716-446655440000",
+                    "offerId": "intro_offer",
+                    "timestamp": 1681314324000,
+                    "keyIdentifier": "ABC123DEF4"
+                }
+            }
+        }
+        self.assertEqual(json_dict, expected)
+
+    def test_empty_response_serialization(self):
+        response = RealtimeResponseBody()
+        json_dict = response.to_json_dict()
+
+        # Should be completely empty when no fields are set
+        self.assertEqual(json_dict, {})
+
+    def test_partial_fields_omitted(self):
+        # Test that None fields in nested objects are omitted
+        response = RealtimeResponseBody(
+            message=Message()  # messageIdentifier is None
+        )
+        json_dict = response.to_json_dict()
+
+        # Should include empty message object (this is correct behavior)
+        self.assertEqual(json_dict, {"message": {}})
+
+    def test_partial_nested_object_serialization(self):
+        # Test nested object with only some fields populated
+        v1_signature = PromotionalOfferSignatureV1(
+            encodedSignature="signature123",
+            productId="com.example.product"
+            # Other fields are None and should be omitted
+        )
+
+        response = RealtimeResponseBody(
+            promotionalOffer=PromotionalOffer(
+                messageIdentifier="msgABC",
+                promotionalOfferSignatureV1=v1_signature
+                # promotionalOfferSignatureV2 is None and should be omitted
+            )
+        )
+        json_dict = response.to_json_dict()
+
+        expected = {
+            "promotionalOffer": {
+                "messageIdentifier": "msgABC",
+                "promotionalOfferSignatureV1": {
+                    "encodedSignature": "signature123",
+                    "productId": "com.example.product"
+                }
+            }
+        }
+        self.assertEqual(json_dict, expected)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR adds a `RealtimeResponseBody` model to help facilitate crafting a response to the Retention Messaging API realtime request with a `to_json_dict` helper function.

Related to #152
