### PR TITLE
Add URLs to package metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,12 @@ dependencies = [
 [project.optional-dependencies]
 async = ["httpx"]
 
+[project.urls]
+Documentation = "https://apple.github.io/app-store-server-library-python/"
+Repository = "https://github.com/apple/app-store-server-library-python"
+Issues = "https://github.com/apple/app-store-server-library-python/issues"
+Changelog = "https://github.com/apple/app-store-server-library-python/blob/main/CHANGELOG.md"
+
 [tool.setuptools]
 packages = {find = {exclude = ["tests"]}}
 


### PR DESCRIPTION
This allows other tools, such as PyPI, Dependabot, Renovate, etc., to provide more details and easier access to information about changes in each update of the package.

Currently, you have to guess as to where to find this repository, which isn't ideal.

The URLs provided are based on what is mentioned in the documentation at https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#urls. I didn't add the "Homepage" URL since I don't know what site you might want to point this at.