### PR TITLE
Add AppReceiptVerifier for signature validation of legacy app receipts

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,31 @@ except APIException as e:
 
 ```
 
+### App Receipt Verification Usage
+
+```python
+from appstoreserverlibrary.app_receipt_verifier import AppReceiptVerifier
+from appstoreserverlibrary.models.Environment import Environment
+from appstoreserverlibrary.signed_data_verifier import VerificationException
+
+root_certificates = load_root_certificates()
+enable_online_checks = True
+bundle_id = "com.example"
+environment = Environment.SANDBOX
+app_receipt_verifier = AppReceiptVerifier(root_certificates, enable_online_checks, environment, bundle_id)
+
+app_receipt = "MI.."
+
+try:
+    receipt = app_receipt_verifier.verify_and_decode_app_receipt(app_receipt)
+    print(receipt)
+
+    transaction_id = app_receipt_verifier.verify_and_extract_transaction_id(app_receipt)
+    print(transaction_id)
+except VerificationException as e:
+    print(e)
+```
+
 ### Promotional Offer Signature Creation
 
 ```python

--- a/appstoreserverlibrary/app_receipt_verifier.py
+++ b/appstoreserverlibrary/app_receipt_verifier.py
@@ -48,6 +48,13 @@ IAP_IS_IN_INTRO_OFFER_PERIOD = 1719
 # is otherwise rejected rather than trusted.
 _DIGESTS = {SHA1_OID: ('sha1', hashes.SHA1), SHA256_OID: ('sha256', hashes.SHA256)}
 
+# Bounds on what is read before the receipt has been verified, so that a hostile receipt cannot make parsing
+# expensive: the nesting a genuine receipt uses with room to spare, an object identifier wider than any real
+# one, and the certificates a chain can hold.
+MAXIMUM_ASN1_DEPTH = 32
+MAXIMUM_OID_BYTES = 32
+MAXIMUM_EMBEDDED_CERTIFICATES = 10
+
 # Only explicit production values map to the Production environment; an unknown
 # or missing receipt type maps to None and fails environment validation.
 _ENVIRONMENT_BY_RECEIPT_TYPE = {
@@ -140,6 +147,11 @@ class AppReceiptVerifier:
         _ChainVerifier, which enforces the chain length, the WWDR intermediate OID and the receipt-signing leaf
         OID, and validates to the caller-supplied Apple roots.
         """
+        # The embedded certificates are attacker-supplied and are parsed and ordered into a chain below, before
+        # anything about the receipt has been verified, so a receipt carrying more of them than a chain can hold
+        # is rejected here rather than assembled
+        if len(signed_data.certificates) > MAXIMUM_EMBEDDED_CERTIFICATES:
+            raise VerificationException(VerificationStatus.INVALID_CHAIN_LENGTH)
         try:
             certificates = [(der, x509.load_der_x509_certificate(der)) for der in signed_data.certificates]
         except Exception as e:
@@ -176,8 +188,13 @@ class _SignedData(NamedTuple):
     certificates: List[bytes]
     signer: _Signer
 
-def _read_element(data: bytes, offset: int) -> _Element:
+def _read_element(data: bytes, offset: int, depth: int = 0) -> _Element:
     """Reads one BER/DER element, supporting the indefinite lengths genuine App Store receipts use."""
+    # Finding the end of an indefinite-length element means walking everything inside it, and its parent walked
+    # it too, so the work grows with the nesting depth. Genuine receipts nest a handful of levels; the bound
+    # keeps a receipt built only to be deeply nested from being expensive to reject.
+    if depth > MAXIMUM_ASN1_DEPTH:
+        raise ValueError('ASN.1 element is nested too deeply')
     if offset + 2 > len(data):
         raise ValueError('Truncated ASN.1 element')
     tag = data[offset]
@@ -194,7 +211,7 @@ def _read_element(data: bytes, offset: int) -> _Element:
                 raise ValueError('Unterminated indefinite-length ASN.1 element')
             if data[position] == 0x00 and data[position + 1] == 0x00:
                 return _Element(tag, offset, content_start, position, position + 2)
-            position = _read_element(data, position).end
+            position = _read_element(data, position, depth + 1).end
     if length & 0x80:
         count = length & 0x7F
         if count > 4 or position + count > len(data):
@@ -205,11 +222,15 @@ def _read_element(data: bytes, offset: int) -> _Element:
         raise ValueError('ASN.1 length exceeds the available input')
     return _Element(tag, offset, position, position + length, position + length)
 
-def _children(data: bytes, element: _Element) -> List[_Element]:
+def _children(data: bytes, element: _Element, depth: int = 0) -> List[_Element]:
     children = []
     position = element.content_start
     while position < element.content_end:
-        child = _read_element(data, position)
+        child = _read_element(data, position, depth + 1)
+        # A child that runs past its parent is rejected rather than read, so a nested element can never be
+        # interpreted from bytes outside the element that declares it
+        if child.end > element.content_end:
+            raise ValueError('ASN.1 element runs past the end of its parent')
         children.append(child)
         position = child.end
     return children
@@ -217,17 +238,19 @@ def _children(data: bytes, element: _Element) -> List[_Element]:
 def _content(data: bytes, element: _Element) -> bytes:
     return data[element.content_start:element.content_end]
 
-def _octets(data: bytes, element: _Element, what: str) -> bytes:
+def _octets(data: bytes, element: _Element, what: str, depth: int = 0) -> bytes:
     """The value of an OCTET STRING, joining the segments BER splits long values into."""
     if element.tag & ~0x20 != 0x04:
         raise ValueError(what + ' is not an ASN.1 octet string')
     if not element.tag & 0x20:
         return _content(data, element)
-    return b''.join(_octets(data, child, what) for child in _children(data, element))
+    if depth > MAXIMUM_ASN1_DEPTH:
+        raise ValueError('ASN.1 element is nested too deeply')
+    return b''.join(_octets(data, child, what, depth + 1) for child in _children(data, element, depth))
 
 def _decode_oid(data: bytes, element: _Element) -> str:
     body = _content(data, element)
-    if not body or body[-1] & 0x80:
+    if not body or len(body) > MAXIMUM_OID_BYTES or body[-1] & 0x80:
         raise ValueError('Malformed ASN.1 object identifier')
     arcs = []
     value = 0

--- a/appstoreserverlibrary/app_receipt_verifier.py
+++ b/appstoreserverlibrary/app_receipt_verifier.py
@@ -1,0 +1,461 @@
+# Copyright (c) 2026 Apple Inc. Licensed under MIT License.
+
+import datetime
+import hashlib
+import hmac
+import time
+from base64 import b64decode, b64encode
+from typing import Dict, List, NamedTuple, Optional, Tuple
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding, rsa
+
+from .models.AppReceipt import AppReceipt
+from .models.Environment import Environment
+from .models.InAppPurchaseReceipt import InAppPurchaseReceipt
+
+from .signed_data_verifier import _ChainVerifier, VerificationException, VerificationStatus
+
+PKCS7_SIGNED_DATA_OID = "1.2.840.113549.1.7.2"
+MESSAGE_DIGEST_OID = "1.2.840.113549.1.9.4"
+SHA1_OID = "1.3.14.3.2.26"
+SHA256_OID = "2.16.840.1.101.3.4.2.1"
+
+ATTR_RECEIPT_TYPE = 0
+ATTR_BUNDLE_ID = 2
+ATTR_APP_VERSION = 3
+ATTR_OPAQUE_VALUE = 4
+ATTR_SHA1_HASH = 5
+ATTR_CREATION_DATE = 12
+ATTR_IN_APP = 17
+ATTR_ORIGINAL_PURCHASE_DATE = 18
+ATTR_ORIGINAL_APP_VERSION = 19
+ATTR_EXPIRATION_DATE = 21
+
+IAP_QUANTITY = 1701
+IAP_PRODUCT_ID = 1702
+IAP_TRANSACTION_ID = 1703
+IAP_PURCHASE_DATE = 1704
+IAP_ORIGINAL_TRANSACTION_ID = 1705
+IAP_ORIGINAL_PURCHASE_DATE = 1706
+IAP_EXPIRES_DATE = 1708
+IAP_WEB_ORDER_LINE_ITEM_ID = 1711
+IAP_CANCELLATION_DATE = 1712
+IAP_IS_IN_INTRO_OFFER_PERIOD = 1719
+
+# Only the digests Apple signs receipts with; the algorithm named by the signer
+# is otherwise rejected rather than trusted.
+_DIGESTS = {SHA1_OID: ('sha1', hashes.SHA1), SHA256_OID: ('sha256', hashes.SHA256)}
+
+# Only explicit production values map to the Production environment; an unknown
+# or missing receipt type maps to None and fails environment validation.
+_ENVIRONMENT_BY_RECEIPT_TYPE = {
+    'Production': Environment.PRODUCTION,
+    'ProductionVPP': Environment.PRODUCTION,
+    'ProductionSandbox': Environment.SANDBOX,
+    'ProductionVPPSandbox': Environment.SANDBOX,
+    'Xcode': Environment.XCODE,
+    'LocalTesting': Environment.LOCAL_TESTING,
+}
+
+class AppReceiptVerifier:
+    """
+    A class providing utility methods for verifying and decoding legacy PKCS#7 App Store receipts, the app receipt
+    used with the deprecated verifyReceipt endpoint.
+
+    This is the validating counterpart to ReceiptUtility, which extracts without validation. The receipt's
+    certificate chain is validated with the same chain verification used for JWS signed data, against the same
+    caller-supplied Apple root certificates, and evaluated at the receipt's creation date so old receipts survive
+    certificate rotations unless online checks are enabled.
+    """
+    def __init__(
+        self,
+        root_certificates: List[bytes],
+        enable_online_checks: bool,
+        environment: Environment,
+        bundle_id: str,
+    ):
+        self._chain_verifier = _ChainVerifier(root_certificates)
+        self._environment = environment
+        self._bundle_id = bundle_id
+        self._enable_online_checks = enable_online_checks
+
+    def verify_and_decode_app_receipt(self, encoded_receipt: str) -> AppReceipt:
+        """
+        Verifies and decodes an app receipt, as obtained from a device
+        See https://developer.apple.com/documentation/appstorereceipts
+
+        :param encoded_receipt: The base64-encoded app receipt
+        :return: The decoded receipt after verification
+        :throws VerificationException: Thrown if the receipt could not be verified
+        """
+        try:
+            try:
+                # Whitespace is stripped rather than rejected, tolerating the line breaks base64 receipts
+                # commonly pick up in transit
+                receipt_der = b64decode(''.join(encoded_receipt.split()), validate=True)
+            except (ValueError, TypeError, AttributeError) as e:
+                raise VerificationException(VerificationStatus.VERIFICATION_FAILURE) from e
+            signed_data = _parse_signed_data(receipt_der)
+            # Parsed before signature verification only to learn the creation date (chain validity is anchored
+            # at signing time); nothing from it is trusted until the chain and signature checks pass.
+            receipt = _parse_receipt_payload(signed_data.content)
+            if self._environment != Environment.XCODE and self._environment != Environment.LOCAL_TESTING:
+                effective_date = time.time() if self._enable_online_checks or receipt.receiptCreationDate is None else receipt.receiptCreationDate // 1000
+                signing_key = self._verify_chain(signed_data, effective_date)
+                _verify_signature(signed_data, signing_key)
+            # In the Xcode and LocalTesting environments the data is not signed by the App Store and signature
+            # verification is skipped, but the bundle id and environment are still validated
+            if receipt.bundleId != self._bundle_id:
+                raise VerificationException(VerificationStatus.INVALID_APP_IDENTIFIER)
+            if _ENVIRONMENT_BY_RECEIPT_TYPE.get(receipt.receiptType) != self._environment:
+                raise VerificationException(VerificationStatus.INVALID_ENVIRONMENT)
+            return receipt
+        except VerificationException as e:
+            raise e
+        except Exception as e:
+            raise VerificationException(VerificationStatus.VERIFICATION_FAILURE) from e
+
+    def verify_and_extract_transaction_id(self, encoded_receipt: str) -> Optional[str]:
+        """
+        Verifies an app receipt and extracts a transaction id from its in-app purchases, the validated counterpart
+        of ReceiptUtility.extract_transaction_id_from_app_receipt, with the same output contract
+
+        :param encoded_receipt: The base64-encoded app receipt
+        :return: A transaction id from the array of in-app purchases, None if the receipt contains no in-app purchases
+        :throws VerificationException: Thrown if the receipt could not be verified
+        """
+        receipt = self.verify_and_decode_app_receipt(encoded_receipt)
+        for purchase in receipt.inAppPurchases:
+            if purchase.transactionId is not None:
+                return purchase.transactionId
+            if purchase.originalTransactionId is not None:
+                return purchase.originalTransactionId
+        return None
+
+    def _verify_chain(self, signed_data: '_SignedData', effective_date: float) -> str:
+        """
+        Orders the receipt's embedded certificates as leaf, intermediate, root and hands them to the shared
+        _ChainVerifier, which enforces the chain length, the WWDR intermediate OID and the receipt-signing leaf
+        OID, and validates to the caller-supplied Apple roots.
+        """
+        try:
+            certificates = [(der, x509.load_der_x509_certificate(der)) for der in signed_data.certificates]
+        except Exception as e:
+            raise VerificationException(VerificationStatus.INVALID_CERTIFICATE) from e
+        ordered = [_find_signer_certificate(certificates, signed_data)]
+        while len(ordered) < len(certificates):
+            issuer = next((c for c in certificates if c not in ordered and c[1].subject == ordered[-1][1].issuer), None)
+            if issuer is None:
+                break
+            ordered.append(issuer)
+        return self._chain_verifier.verify_chain(
+            [b64encode(der).decode() for der, _ in ordered], self._enable_online_checks, effective_date
+        )
+
+class _Element(NamedTuple):
+    """One parsed ASN.1 element, as offsets into the buffer it was read from."""
+    tag: int
+    start: int
+    content_start: int
+    content_end: int
+    end: int
+
+class _Signer(NamedTuple):
+    """The fields of a CMS SignerInfo this library uses."""
+    issuer: Optional[bytes]
+    serial_number: Optional[int]
+    subject_key_identifier: Optional[bytes]
+    digest_oid: str
+    signed_attributes: Optional[bytes]
+    signature: bytes
+
+class _SignedData(NamedTuple):
+    content: bytes
+    certificates: List[bytes]
+    signer: _Signer
+
+def _read_element(data: bytes, offset: int) -> _Element:
+    """Reads one BER/DER element, supporting the indefinite lengths genuine App Store receipts use."""
+    if offset + 2 > len(data):
+        raise ValueError('Truncated ASN.1 element')
+    tag = data[offset]
+    if tag & 0x1F == 0x1F:
+        raise ValueError('Multi-byte ASN.1 tags are not supported')
+    position = offset + 2
+    length = data[offset + 1]
+    if length == 0x80:
+        if not tag & 0x20:
+            raise ValueError('Primitive ASN.1 element with an indefinite length')
+        content_start = position
+        while True:
+            if position + 2 > len(data):
+                raise ValueError('Unterminated indefinite-length ASN.1 element')
+            if data[position] == 0x00 and data[position + 1] == 0x00:
+                return _Element(tag, offset, content_start, position, position + 2)
+            position = _read_element(data, position).end
+    if length & 0x80:
+        count = length & 0x7F
+        if count > 4 or position + count > len(data):
+            raise ValueError('Unsupported ASN.1 length')
+        length = int.from_bytes(data[position:position + count], 'big')
+        position += count
+    if position + length > len(data):
+        raise ValueError('ASN.1 length exceeds the available input')
+    return _Element(tag, offset, position, position + length, position + length)
+
+def _children(data: bytes, element: _Element) -> List[_Element]:
+    children = []
+    position = element.content_start
+    while position < element.content_end:
+        child = _read_element(data, position)
+        children.append(child)
+        position = child.end
+    return children
+
+def _content(data: bytes, element: _Element) -> bytes:
+    return data[element.content_start:element.content_end]
+
+def _octets(data: bytes, element: _Element, what: str) -> bytes:
+    """The value of an OCTET STRING, joining the segments BER splits long values into."""
+    if element.tag & ~0x20 != 0x04:
+        raise ValueError(what + ' is not an ASN.1 octet string')
+    if not element.tag & 0x20:
+        return _content(data, element)
+    return b''.join(_octets(data, child, what) for child in _children(data, element))
+
+def _decode_oid(data: bytes, element: _Element) -> str:
+    body = _content(data, element)
+    if not body or body[-1] & 0x80:
+        raise ValueError('Malformed ASN.1 object identifier')
+    arcs = []
+    value = 0
+    for byte in body:
+        value = value << 7 | (byte & 0x7F)
+        if not byte & 0x80:
+            arcs.append(value)
+            value = 0
+    first = arcs[0]
+    if first < 80:
+        leading = [first // 40, first % 40]
+    else:
+        leading = [2, first - 80]
+    return '.'.join(str(arc) for arc in leading + arcs[1:])
+
+def _expect(data: bytes, element: _Element, tag: int, what: str) -> _Element:
+    if element.tag != tag:
+        raise ValueError(what + ' has an unexpected ASN.1 tag')
+    return element
+
+def _parse_signed_data(receipt_der: bytes) -> _SignedData:
+    content_info = _read_element(receipt_der, 0)
+    # Parsing must exhaust the input, rejecting trailing bytes after the CMS blob
+    if content_info.tag != 0x30 or content_info.end != len(receipt_der):
+        raise ValueError('Receipt is not a PKCS#7 container')
+    fields = _children(receipt_der, content_info)
+    if len(fields) != 2 or _decode_oid(receipt_der, _expect(receipt_der, fields[0], 0x06, 'Content type')) != PKCS7_SIGNED_DATA_OID:
+        raise ValueError('Receipt is not a PKCS#7 container')
+    wrapped = _children(receipt_der, _expect(receipt_der, fields[1], 0xA0, 'Signed data'))
+    if len(wrapped) != 1:
+        raise ValueError('Receipt is not a PKCS#7 container')
+    signed_data = _children(receipt_der, _expect(receipt_der, wrapped[0], 0x30, 'Signed data'))
+    if len(signed_data) < 4:
+        raise ValueError('Receipt is not a PKCS#7 container')
+    content = _parse_encapsulated_content(receipt_der, _expect(receipt_der, signed_data[2], 0x30, 'Encapsulated content'))
+    # Everything after the encapsulated content is optional but for the signer infos: the certificates and the
+    # revocation lists carry context tags, so the SET among them is the signer infos
+    optional = signed_data[3:]
+    certificates = [receipt_der[child.start:child.end] for element in optional if element.tag == 0xA0 for child in _children(receipt_der, element)]
+    signers = [child for element in optional if element.tag == 0x31 for child in _children(receipt_der, element)]
+    if not signers:
+        raise ValueError('Receipt has no signer info')
+    return _SignedData(content, certificates, _parse_signer(receipt_der, signers[0]))
+
+def _parse_encapsulated_content(data: bytes, encapsulated: _Element) -> bytes:
+    fields = _children(data, encapsulated)
+    if len(fields) < 2:
+        raise ValueError('Receipt has no encapsulated payload')
+    wrapped = _children(data, _expect(data, fields[1], 0xA0, 'Encapsulated payload'))
+    if len(wrapped) != 1:
+        raise ValueError('Receipt has no encapsulated payload')
+    return _octets(data, wrapped[0], 'Encapsulated payload')
+
+def _parse_signer(data: bytes, signer_info: _Element) -> _Signer:
+    fields = _children(data, _expect(data, signer_info, 0x30, 'Signer info'))
+    if len(fields) < 5:
+        raise ValueError('Signer info has too few fields')
+    issuer = None
+    serial_number = None
+    subject_key_identifier = None
+    if fields[1].tag == 0x30:
+        identifier = _children(data, fields[1])
+        if len(identifier) != 2:
+            raise ValueError('Malformed signer identifier')
+        issuer = data[identifier[0].start:identifier[0].end]
+        serial_number = int.from_bytes(_content(data, _expect(data, identifier[1], 0x02, 'Serial number')), 'big', signed=True)
+    elif fields[1].tag == 0x80:
+        subject_key_identifier = _content(data, fields[1])
+    else:
+        raise ValueError('Malformed signer identifier')
+    digest_oid = _decode_oid(data, _expect(data, _children(data, _expect(data, fields[2], 0x30, 'Digest algorithm'))[0], 0x06, 'Digest algorithm'))
+    signed_attributes = None
+    remaining = fields[3:]
+    if remaining[0].tag == 0xA0:
+        signed_attributes = data[remaining[0].start:remaining[0].end]
+        remaining = remaining[1:]
+    if len(remaining) < 2:
+        raise ValueError('Signer info has too few fields')
+    signature = _octets(data, remaining[1], 'Signature')
+    return _Signer(issuer, serial_number, subject_key_identifier, digest_oid, signed_attributes, signature)
+
+def _find_signer_certificate(certificates: List[Tuple[bytes, x509.Certificate]], signed_data: _SignedData) -> Tuple[bytes, x509.Certificate]:
+    for candidate in certificates:
+        if signed_data.signer.subject_key_identifier is not None:
+            try:
+                key_identifier = candidate[1].extensions.get_extension_for_class(x509.SubjectKeyIdentifier).value.digest
+            except x509.ExtensionNotFound:
+                continue
+            if key_identifier == signed_data.signer.subject_key_identifier:
+                return candidate
+        elif candidate[1].serial_number == signed_data.signer.serial_number and candidate[1].issuer.public_bytes() == signed_data.signer.issuer:
+            return candidate
+    raise VerificationException(VerificationStatus.INVALID_CHAIN)
+
+def _verify_signature(signed_data: _SignedData, signing_key: str):
+    digest = _DIGESTS.get(signed_data.signer.digest_oid)
+    if digest is None:
+        raise ValueError('Unrecognized receipt digest algorithm ' + signed_data.signer.digest_oid)
+    public_key = serialization.load_pem_public_key(signing_key.encode())
+    if not isinstance(public_key, rsa.RSAPublicKey):
+        raise ValueError('Receipt signer key is not RSA')
+    if signed_data.signer.signed_attributes is not None:
+        signed_attributes = signed_data.signer.signed_attributes
+        if not hmac.compare_digest(
+            _message_digest_attribute(signed_attributes), hashlib.new(digest[0], signed_data.content).digest()
+        ):
+            raise ValueError('Receipt messageDigest attribute does not match the payload')
+        # The signature covers the signed attributes re-encoded as an explicit SET (RFC 5652 5.4), so the
+        # implicit [0] tag is swapped for a SET tag
+        signed_bytes = b'\x31' + signed_attributes[1:]
+    else:
+        signed_bytes = signed_data.content
+    public_key.verify(signed_data.signer.signature, signed_bytes, padding.PKCS1v15(), digest[1]())
+
+def _message_digest_attribute(signed_attributes: bytes) -> bytes:
+    for attribute in _children(signed_attributes, _read_element(signed_attributes, 0)):
+        fields = _children(signed_attributes, _expect(signed_attributes, attribute, 0x30, 'Signed attribute'))
+        if len(fields) == 2 and _decode_oid(signed_attributes, _expect(signed_attributes, fields[0], 0x06, 'Signed attribute')) == MESSAGE_DIGEST_OID:
+            values = _children(signed_attributes, _expect(signed_attributes, fields[1], 0x31, 'Signed attribute'))
+            if len(values) != 1:
+                raise ValueError('Malformed messageDigest attribute')
+            return _octets(signed_attributes, values[0], 'messageDigest attribute')
+    raise ValueError('Receipt has no messageDigest attribute')
+
+def _parse_attribute_set(der: bytes, what: str) -> List[Tuple[int, bytes]]:
+    """
+    Parses a receipt attribute SET, the shape both the receipt payload and the value of an in-app purchase
+    attribute take. Each attribute is SEQUENCE { type INTEGER, version INTEGER, value OCTET STRING }.
+    """
+    element = _read_element(der, 0)
+    if element.tag & ~0x20 == 0x04 and element.end == len(der):
+        # Xcode receipts double-wrap the payload in an extra OCTET STRING; ReceiptUtility handles the same shape
+        der = _octets(der, element, what)
+        element = _read_element(der, 0)
+    if element.tag != 0x31 or element.end != len(der):
+        raise ValueError(what + ' is not an ASN.1 SET')
+    attributes = []
+    for attribute in _children(der, element):
+        fields = _children(der, _expect(der, attribute, 0x30, 'Receipt attribute'))
+        if len(fields) < 3:
+            raise ValueError('Receipt attribute has fewer than 3 fields')
+        attribute_type = _decode_bounded_integer(der, _expect(der, fields[0], 0x02, 'Receipt attribute type'))
+        attributes.append((attribute_type, _octets(der, fields[2], 'Receipt attribute value')))
+    return attributes
+
+def _decode_bounded_integer(data: bytes, element: _Element) -> int:
+    """Non-negative and within 64-bit range; real receipts carry 7-byte integers."""
+    body = _content(data, element)
+    if not body or len(body) > 8 or body[0] & 0x80:
+        raise ValueError('Receipt integer out of range')
+    return int.from_bytes(body, 'big')
+
+def _decode_string(value: bytes) -> str:
+    element = _read_element(value, 0)
+    if element.tag not in (0x0C, 0x16) or element.end != len(value):
+        raise ValueError('Attribute value is not an ASN.1 string')
+    return _content(value, element).decode('utf-8')
+
+def _decode_integer(value: bytes) -> int:
+    element = _read_element(value, 0)
+    if element.tag != 0x02 or element.end != len(value):
+        raise ValueError('Attribute value is not an ASN.1 integer')
+    return _decode_bounded_integer(value, element)
+
+def _decode_date(value: bytes) -> Optional[int]:
+    """RFC 3339 date in an IA5String, in milliseconds; empty means absent (real receipts do this)."""
+    text = _decode_string(value)
+    if text == '':
+        return None
+    parsed = datetime.datetime.fromisoformat(text.replace('Z', '+00:00'))
+    if parsed.tzinfo is None:
+        raise ValueError('Receipt date has no UTC offset: ' + text)
+    return round(parsed.timestamp() * 1000)
+
+def _record_unknown(unknown_attributes: Dict[int, List[bytes]], attribute_type: int, value: bytes):
+    unknown_attributes.setdefault(attribute_type, []).append(value)
+
+def _parse_receipt_payload(payload: bytes) -> AppReceipt:
+    receipt = AppReceipt(inAppPurchases=[], unknownAttributes={})
+    for attribute_type, value in _parse_attribute_set(payload, 'Receipt payload'):
+        if attribute_type == ATTR_RECEIPT_TYPE:
+            receipt.receiptType = _decode_string(value)
+        elif attribute_type == ATTR_BUNDLE_ID:
+            receipt.bundleId = _decode_string(value)
+            receipt.bundleIdBytes = value
+        elif attribute_type == ATTR_APP_VERSION:
+            receipt.applicationVersion = _decode_string(value)
+        elif attribute_type == ATTR_OPAQUE_VALUE:
+            receipt.opaqueValue = value
+        elif attribute_type == ATTR_SHA1_HASH:
+            receipt.sha1Hash = value
+        elif attribute_type == ATTR_CREATION_DATE:
+            receipt.receiptCreationDate = _decode_date(value)
+        elif attribute_type == ATTR_IN_APP:
+            receipt.inAppPurchases.append(_parse_in_app_purchase(value))
+        elif attribute_type == ATTR_ORIGINAL_PURCHASE_DATE:
+            receipt.originalPurchaseDate = _decode_date(value)
+        elif attribute_type == ATTR_ORIGINAL_APP_VERSION:
+            receipt.originalApplicationVersion = _decode_string(value)
+        elif attribute_type == ATTR_EXPIRATION_DATE:
+            receipt.expirationDate = _decode_date(value)
+        else:
+            _record_unknown(receipt.unknownAttributes, attribute_type, value)
+    return receipt
+
+def _parse_in_app_purchase(in_app_set: bytes) -> InAppPurchaseReceipt:
+    purchase = InAppPurchaseReceipt(unknownAttributes={})
+    for attribute_type, value in _parse_attribute_set(in_app_set, 'In-app purchase attribute'):
+        if attribute_type == IAP_QUANTITY:
+            purchase.quantity = _decode_integer(value)
+        elif attribute_type == IAP_PRODUCT_ID:
+            purchase.productId = _decode_string(value)
+        elif attribute_type == IAP_TRANSACTION_ID:
+            purchase.transactionId = _decode_string(value)
+        elif attribute_type == IAP_PURCHASE_DATE:
+            purchase.purchaseDate = _decode_date(value)
+        elif attribute_type == IAP_ORIGINAL_TRANSACTION_ID:
+            purchase.originalTransactionId = _decode_string(value)
+        elif attribute_type == IAP_ORIGINAL_PURCHASE_DATE:
+            purchase.originalPurchaseDate = _decode_date(value)
+        elif attribute_type == IAP_EXPIRES_DATE:
+            purchase.expiresDate = _decode_date(value)
+        elif attribute_type == IAP_WEB_ORDER_LINE_ITEM_ID:
+            purchase.webOrderLineItemId = _decode_integer(value)
+        elif attribute_type == IAP_CANCELLATION_DATE:
+            purchase.cancellationDate = _decode_date(value)
+        elif attribute_type == IAP_IS_IN_INTRO_OFFER_PERIOD:
+            purchase.isInIntroOfferPeriod = _decode_integer(value) != 0
+        else:
+            _record_unknown(purchase.unknownAttributes, attribute_type, value)
+    return purchase

--- a/appstoreserverlibrary/models/AppReceipt.py
+++ b/appstoreserverlibrary/models/AppReceipt.py
@@ -1,0 +1,92 @@
+# Copyright (c) 2026 Apple Inc. Licensed under MIT License.
+from typing import Dict, List, Optional
+
+from attr import define
+import attr
+
+from .InAppPurchaseReceipt import InAppPurchaseReceipt
+
+@define
+class AppReceipt:
+    """
+    A decoded legacy App Store receipt (the PKCS#7 app receipt).
+
+    https://developer.apple.com/documentation/appstorereceipts/responsebody/receipt
+    """
+
+    receiptType: Optional[str] = attr.ib(default=None)
+    """
+    The raw receipt type, e.g. Production, ProductionVPP, ProductionSandbox, ProductionVPPSandbox or Xcode.
+    """
+
+    bundleId: Optional[str] = attr.ib(default=None)
+    """
+    The bundle identifier of the app the receipt belongs to.
+
+    https://developer.apple.com/documentation/appstorereceipts/bundle_id
+    """
+
+    bundleIdBytes: Optional[bytes] = attr.ib(default=None)
+    """
+    The raw ASN.1 bytes of the bundle identifier attribute, needed together with opaqueValue and sha1Hash
+    to compute the device-hash binding described in Apple's receipt validation guide.
+    """
+
+    applicationVersion: Optional[str] = attr.ib(default=None)
+    """
+    The app's version number.
+
+    https://developer.apple.com/documentation/appstorereceipts/application_version
+    """
+
+    opaqueValue: Optional[bytes] = attr.ib(default=None)
+    """
+    An opaque value used, with other data, to compute the device hash.
+    """
+
+    sha1Hash: Optional[bytes] = attr.ib(default=None)
+    """
+    The SHA-1 device-hash attribute of the receipt.
+    """
+
+    receiptCreationDate: Optional[int] = attr.ib(default=None)
+    """
+    The time the App Store generated the receipt, in UNIX time, in milliseconds.
+
+    https://developer.apple.com/documentation/appstorereceipts/receipt_creation_date
+    """
+
+    originalPurchaseDate: Optional[int] = attr.ib(default=None)
+    """
+    The time of the original app purchase, in UNIX time, in milliseconds.
+
+    https://developer.apple.com/documentation/appstorereceipts/original_purchase_date
+    """
+
+    originalApplicationVersion: Optional[str] = attr.ib(default=None)
+    """
+    The version of the app that the user originally purchased.
+
+    https://developer.apple.com/documentation/appstorereceipts/original_application_version
+    """
+
+    expirationDate: Optional[int] = attr.ib(default=None)
+    """
+    The expiration date of the receipt, in UNIX time, in milliseconds. Present for apps purchased through the
+    Volume Purchase Program.
+
+    https://developer.apple.com/documentation/appstorereceipts/expiration_date
+    """
+
+    inAppPurchases: Optional[List[InAppPurchaseReceipt]] = attr.ib(default=None)
+    """
+    The decoded in-app purchase attributes contained in the receipt.
+
+    https://developer.apple.com/documentation/appstorereceipts/responsebody/receipt/in_app
+    """
+
+    unknownAttributes: Optional[Dict[int, List[bytes]]] = attr.ib(default=None)
+    """
+    Attribute types this library does not model, keyed by type, with the verified-but-undecoded value bytes,
+    so fields Apple adds later remain accessible without a library update.
+    """

--- a/appstoreserverlibrary/models/InAppPurchaseReceipt.py
+++ b/appstoreserverlibrary/models/InAppPurchaseReceipt.py
@@ -1,0 +1,89 @@
+# Copyright (c) 2026 Apple Inc. Licensed under MIT License.
+from typing import Dict, List, Optional
+
+from attr import define
+import attr
+
+@define
+class InAppPurchaseReceipt:
+    """
+    A decoded in-app purchase attribute from a legacy App Store receipt.
+
+    https://developer.apple.com/documentation/appstorereceipts/responsebody/receipt/in_app
+    """
+
+    quantity: Optional[int] = attr.ib(default=None)
+    """
+    The number of items purchased.
+
+    https://developer.apple.com/documentation/appstorereceipts/quantity
+    """
+
+    productId: Optional[str] = attr.ib(default=None)
+    """
+    The unique identifier of the product purchased.
+
+    https://developer.apple.com/documentation/appstorereceipts/product_id
+    """
+
+    transactionId: Optional[str] = attr.ib(default=None)
+    """
+    The unique identifier of the transaction.
+
+    https://developer.apple.com/documentation/appstorereceipts/transaction_id
+    """
+
+    originalTransactionId: Optional[str] = attr.ib(default=None)
+    """
+    The unique identifier of the original transaction.
+
+    https://developer.apple.com/documentation/appstorereceipts/original_transaction_id
+    """
+
+    purchaseDate: Optional[int] = attr.ib(default=None)
+    """
+    The time of the purchase, in UNIX time, in milliseconds.
+
+    https://developer.apple.com/documentation/appstorereceipts/purchase_date
+    """
+
+    originalPurchaseDate: Optional[int] = attr.ib(default=None)
+    """
+    The time of the original purchase, in UNIX time, in milliseconds.
+
+    https://developer.apple.com/documentation/appstorereceipts/original_purchase_date
+    """
+
+    expiresDate: Optional[int] = attr.ib(default=None)
+    """
+    The expiration time of the subscription, in UNIX time, in milliseconds.
+
+    https://developer.apple.com/documentation/appstorereceipts/expires_date
+    """
+
+    cancellationDate: Optional[int] = attr.ib(default=None)
+    """
+    The time Apple customer support canceled the transaction or the subscription was upgraded, in UNIX time, in milliseconds.
+
+    https://developer.apple.com/documentation/appstorereceipts/cancellation_date
+    """
+
+    webOrderLineItemId: Optional[int] = attr.ib(default=None)
+    """
+    The unique identifier of subscription purchase events across devices, including subscription renewals.
+
+    https://developer.apple.com/documentation/appstorereceipts/web_order_line_item_id
+    """
+
+    isInIntroOfferPeriod: Optional[bool] = attr.ib(default=None)
+    """
+    Whether the subscription is in an introductory offer period.
+
+    https://developer.apple.com/documentation/appstorereceipts/is_in_intro_offer_period
+    """
+
+    unknownAttributes: Optional[Dict[int, List[bytes]]] = attr.ib(default=None)
+    """
+    Attribute types this library does not model, keyed by type, with the verified-but-undecoded value bytes,
+    so fields Apple adds later remain accessible without a library update.
+    """

--- a/appstoreserverlibrary/receipt_utility.py
+++ b/appstoreserverlibrary/receipt_utility.py
@@ -23,6 +23,7 @@ class ReceiptUtility:
         """
         Extracts a transaction id from an encoded App Receipt. Throws if the receipt does not match the expected format.
         *NO validation* is performed on the receipt, and any data returned should only be used to call the App Store Server API.
+        To verify the receipt's signature before extraction, use appstoreserverlibrary.app_receipt_verifier.AppReceiptVerifier.verify_and_extract_transaction_id.
 
         :param appReceipt: The unmodified app receipt
         :return: A transaction id from the array of in-app purchases, null if the receipt contains no in-app purchases

--- a/tests/receipt_creator.py
+++ b/tests/receipt_creator.py
@@ -1,0 +1,210 @@
+# Copyright (c) 2026 Apple Inc. Licensed under MIT License.
+
+import datetime
+import hashlib
+from typing import List, Optional
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding, rsa
+from cryptography.x509.oid import NameOID
+
+WWDR_INTERMEDIATE_OID = '1.2.840.113635.100.6.2.1'
+RECEIPT_SIGNER_OID = '1.2.840.113635.100.6.11.1'
+
+SHA1_OID = '1.3.14.3.2.26'
+SHA256_OID = '2.16.840.1.101.3.4.2.1'
+SHA512_OID = '2.16.840.1.101.3.4.2.3'
+RSA_ENCRYPTION_OID = '1.2.840.113549.1.1.1'
+PKCS7_DATA_OID = '1.2.840.113549.1.7.1'
+PKCS7_SIGNED_DATA_OID = '1.2.840.113549.1.7.2'
+CONTENT_TYPE_OID = '1.2.840.113549.1.9.3'
+MESSAGE_DIGEST_OID = '1.2.840.113549.1.9.4'
+SIGNING_TIME_OID = '1.2.840.113549.1.9.5'
+
+# The receipt digest, by the name hashlib knows it: the two Apple uses, plus one it does not for the allowlist
+DIGESTS = {'sha1': (hashes.SHA1, SHA1_OID), 'sha256': (hashes.SHA256, SHA256_OID), 'sha512': (hashes.SHA512, SHA512_OID)}
+
+DAY = datetime.timedelta(days=1)
+
+def encode(tag: int, content: bytes) -> bytes:
+    if len(content) < 0x80:
+        return bytes([tag, len(content)]) + content
+    length = len(content).to_bytes((len(content).bit_length() + 7) // 8, 'big')
+    return bytes([tag, 0x80 | len(length)]) + length + content
+
+def encode_integer(value: int) -> bytes:
+    return encode(0x02, value.to_bytes(max(1, (value.bit_length() + 8) // 8), 'big'))
+
+def encode_object_identifier(dotted: str) -> bytes:
+    arcs = [int(arc) for arc in dotted.split('.')]
+    body = bytearray([arcs[0] * 40 + arcs[1]])
+    for arc in arcs[2:]:
+        chunk = [arc & 0x7F]
+        arc >>= 7
+        while arc:
+            chunk.append(0x80 | (arc & 0x7F))
+            arc >>= 7
+        body += bytes(reversed(chunk))
+    return encode(0x06, bytes(body))
+
+def encode_sequence(*parts: bytes) -> bytes:
+    return encode(0x30, b''.join(parts))
+
+def encode_set(*parts: bytes) -> bytes:
+    return encode(0x31, b''.join(parts))
+
+def encode_context(number: int, content: bytes) -> bytes:
+    return encode(0xA0 | number, content)
+
+def encode_segmented_octet_string(value: bytes, segment_size: int) -> bytes:
+    """A constructed OCTET STRING, the shape BER splits a long value into and the one genuine receipts use."""
+    return encode(0x24, b''.join(encode(0x04, value[offset:offset + segment_size]) for offset in range(0, len(value), segment_size)))
+
+def encode_algorithm(oid: str) -> bytes:
+    return encode_sequence(encode_object_identifier(oid), b'\x05\x00')
+
+def encode_utc_time(when: datetime.datetime) -> bytes:
+    return encode(0x17, when.astimezone(datetime.timezone.utc).strftime('%y%m%d%H%M%SZ').encode())
+
+class AttributeSet:
+    """
+    Builds a receipt attribute SET, the shape both the receipt payload and the value of an in-app purchase
+    attribute take. Each attribute is SEQUENCE { type INTEGER, version INTEGER, value OCTET STRING }.
+    """
+    def __init__(self):
+        self._attributes: List[bytes] = []
+
+    def string(self, attribute_type: int, value: str) -> 'AttributeSet':
+        """An attribute whose value is a DER UTF8String, e.g. the bundle identifier."""
+        return self.raw(attribute_type, encode(0x0C, value.encode('utf-8')))
+
+    def date(self, attribute_type: int, value: str) -> 'AttributeSet':
+        """An attribute whose value is a DER IA5String holding an RFC 3339 date."""
+        return self.raw(attribute_type, encode(0x16, value.encode('ascii')))
+
+    def integer(self, attribute_type: int, value: int) -> 'AttributeSet':
+        """An attribute whose value is a DER INTEGER, e.g. a purchase quantity."""
+        return self.raw(attribute_type, encode_integer(value))
+
+    def raw(self, attribute_type: int, value: bytes) -> 'AttributeSet':
+        """An attribute whose value bytes are used as-is, e.g. an opaque value or a nested SET."""
+        self._attributes.append(encode_sequence(encode_integer(attribute_type), encode_integer(1), encode(0x04, value)))
+        return self
+
+    def build(self) -> bytes:
+        return encode_set(*self._attributes)
+
+class ReceiptCreator:
+    """
+    Generates a throwaway "Apple-like" RSA PKI (root, WWDR intermediate, receipt signing leaf) and CMS-signs
+    synthetic legacy app receipts with it, so AppReceiptVerifier can be exercised without any real Apple key
+    material or a checked-in receipt.
+    """
+    def __init__(self, chain: List[x509.Certificate], signing_key: rsa.RSAPrivateKey):
+        # Leaf first, then intermediate, then root; a self-signed creator holds one entry
+        self._chain = chain
+        self._signing_key = signing_key
+
+    def get_root_certificate(self) -> bytes:
+        """The root of this chain, in the form the verifier's constructor accepts."""
+        return self._chain[-1].public_bytes(serialization.Encoding.DER)
+
+    def sign_receipt(self, payload: bytes, embedded_certificates: Optional[int] = None, signing_time: Optional[datetime.datetime] = None, signed_attributes: bool = True, digest: str = 'sha256', content_segment_size: Optional[int] = None) -> bytes:
+        """
+        CMS-signs the payload as encapsulated content, embedding the chain.
+
+        :param embedded_certificates: How many certificates of the chain, starting at the leaf, to embed
+        :param signing_time: The CMS signing time attribute, which an old receipt signed by a since expired
+            certificate carries from when it was created
+        :param signed_attributes: Whether the signer authenticates attributes and signs those instead of signing
+            the payload directly, as Apple's own receipts do not
+        :param digest: The digest the signer names and signs with, by its hashlib name
+        :param content_segment_size: Encodes the payload as a constructed OCTET STRING of segments this size
+        """
+        embedded = self._chain[:embedded_certificates] if embedded_certificates is not None else self._chain
+        algorithm, digest_oid = DIGESTS[digest]
+        if signed_attributes:
+            attributes = b''.join([
+                encode_sequence(encode_object_identifier(CONTENT_TYPE_OID), encode_set(encode_object_identifier(PKCS7_DATA_OID))),
+                encode_sequence(encode_object_identifier(SIGNING_TIME_OID), encode_set(encode_utc_time(signing_time if signing_time is not None else datetime.datetime.now(datetime.timezone.utc)))),
+                encode_sequence(encode_object_identifier(MESSAGE_DIGEST_OID), encode_set(encode(0x04, hashlib.new(digest, payload).digest()))),
+            ])
+            # The signature covers the signed attributes as an explicit SET, not with their implicit [0] tag
+            signature = self._signing_key.sign(encode_set(attributes), padding.PKCS1v15(), algorithm())
+            attributes_field = [encode_context(0, attributes)]
+        else:
+            signature = self._signing_key.sign(payload, padding.PKCS1v15(), algorithm())
+            attributes_field = []
+        signer_info = encode_sequence(
+            encode_integer(1),
+            encode_sequence(self._chain[0].issuer.public_bytes(), encode_integer(self._chain[0].serial_number)),
+            encode_algorithm(digest_oid),
+            *attributes_field,
+            encode_algorithm(RSA_ENCRYPTION_OID),
+            encode(0x04, signature),
+        )
+        signed_data = encode_sequence(
+            encode_integer(1),
+            encode_set(encode_algorithm(digest_oid)),
+            encode_sequence(encode_object_identifier(PKCS7_DATA_OID), encode_context(0, encode(0x04, payload) if content_segment_size is None else encode_segmented_octet_string(payload, content_segment_size))),
+            encode_context(0, b''.join(certificate.public_bytes(serialization.Encoding.DER) for certificate in embedded)),
+            encode_set(signer_info),
+        )
+        return encode_sequence(encode_object_identifier(PKCS7_SIGNED_DATA_OID), encode_context(0, signed_data))
+
+def double_wrap(payload: bytes) -> bytes:
+    """The extra OCTET STRING wrapper Xcode-generated receipts put around the payload."""
+    return encode(0x04, payload)
+
+def create_receipt_creator(receipt_signer_oid: bool = True, wwdr_intermediate_oid: bool = True, not_before: Optional[datetime.datetime] = None, not_after: Optional[datetime.datetime] = None) -> ReceiptCreator:
+    """
+    A chain carrying both Apple marker OIDs, by default with a validity window wide enough to cover any
+    plausible receipt creation date; the chain of a receipt is evaluated at the date the receipt was created,
+    not now.
+
+    :param receipt_signer_oid: Whether the leaf carries the receipt-signing marker OID
+    :param wwdr_intermediate_oid: Whether the intermediate carries the WWDR marker OID
+    :param not_before: The start of the validity window of every certificate in the chain
+    :param not_after: The end of the validity window of every certificate in the chain
+    """
+    not_before = days_ago(3650) if not_before is None else not_before
+    not_after = in_one_year() if not_after is None else not_after
+    root_key = _rsa_key()
+    intermediate_key = _rsa_key()
+    leaf_key = _rsa_key()
+    root = _certificate('Test App Store Root CA', root_key.public_key(), 'Test App Store Root CA', root_key, True, None, not_before, not_after)
+    intermediate = _certificate('Test WWDR CA', intermediate_key.public_key(), 'Test App Store Root CA', root_key, True, WWDR_INTERMEDIATE_OID if wwdr_intermediate_oid else None, not_before, not_after)
+    leaf = _certificate('Test Receipt Signing', leaf_key.public_key(), 'Test WWDR CA', intermediate_key, False, RECEIPT_SIGNER_OID if receipt_signer_oid else None, not_before, not_after)
+    return ReceiptCreator([leaf, intermediate, root], leaf_key)
+
+def create_self_signed_receipt_creator() -> ReceiptCreator:
+    """A single self-signed certificate, as an Xcode-generated receipt carries; such a receipt is never chain verified."""
+    key = _rsa_key()
+    certificate = _certificate('Test Xcode Receipt Signing', key.public_key(), 'Test Xcode Receipt Signing', key, False, RECEIPT_SIGNER_OID, days_ago(3650), in_one_year())
+    return ReceiptCreator([certificate], key)
+
+def days_ago(days: int) -> datetime.datetime:
+    return datetime.datetime.now(datetime.timezone.utc) - days * DAY
+
+def in_one_year() -> datetime.datetime:
+    return datetime.datetime.now(datetime.timezone.utc) + 365 * DAY
+
+def _rsa_key() -> rsa.RSAPrivateKey:
+    return rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+def _certificate(subject: str, subject_key: rsa.RSAPublicKey, issuer: str, issuer_key: rsa.RSAPrivateKey, certificate_authority: bool, marker_oid: Optional[str], not_before: datetime.datetime, not_after: datetime.datetime) -> x509.Certificate:
+    builder = (
+        x509.CertificateBuilder()
+        .subject_name(x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, subject)]))
+        .issuer_name(x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, issuer)]))
+        .public_key(subject_key)
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(not_before)
+        .not_valid_after(not_after)
+        .add_extension(x509.BasicConstraints(ca=certificate_authority, path_length=None), critical=True)
+    )
+    if marker_oid is not None:
+        # The Apple marker extensions are non-critical and carry no value
+        builder = builder.add_extension(x509.UnrecognizedExtension(x509.ObjectIdentifier(marker_oid), b'\x05\x00'), critical=False)
+    return builder.sign(issuer_key, hashes.SHA256())

--- a/tests/receipt_creator.py
+++ b/tests/receipt_creator.py
@@ -110,7 +110,7 @@ class ReceiptCreator:
         """The root of this chain, in the form the verifier's constructor accepts."""
         return self._chain[-1].public_bytes(serialization.Encoding.DER)
 
-    def sign_receipt(self, payload: bytes, embedded_certificates: Optional[int] = None, signing_time: Optional[datetime.datetime] = None, signed_attributes: bool = True, digest: str = 'sha256', content_segment_size: Optional[int] = None) -> bytes:
+    def sign_receipt(self, payload: bytes, embedded_certificates: Optional[int] = None, signing_time: Optional[datetime.datetime] = None, signed_attributes: bool = True, digest: str = 'sha256', content_segment_size: Optional[int] = None, padding_certificates: int = 0, subject_key_identifier: bool = False, encoded_content: Optional[bytes] = None) -> bytes:
         """
         CMS-signs the payload as encapsulated content, embedding the chain.
 
@@ -121,8 +121,17 @@ class ReceiptCreator:
             the payload directly, as Apple's own receipts do not
         :param digest: The digest the signer names and signs with, by its hashlib name
         :param content_segment_size: Encodes the payload as a constructed OCTET STRING of segments this size
+        :param padding_certificates: Unrelated certificates embedded on top of the chain, as a receipt bloated
+            to make chain assembly expensive carries
+        :param subject_key_identifier: Whether the signer names its certificate by subject key identifier
+            rather than by issuer and serial number
+        :param encoded_content: The already-encoded encapsulated content, in place of encoding the payload
         """
-        embedded = self._chain[:embedded_certificates] if embedded_certificates is not None else self._chain
+        embedded = list(self._chain[:embedded_certificates] if embedded_certificates is not None else self._chain)
+        for index in range(padding_certificates):
+            key = _rsa_key()
+            # Carries the intermediate's subject name, so it stays a candidate at every step of chain assembly
+            embedded.append(_certificate('Test WWDR CA', key.public_key(), 'Test WWDR CA', key, True, None, days_ago(3650), in_one_year()))
         algorithm, digest_oid = DIGESTS[digest]
         if signed_attributes:
             attributes = b''.join([
@@ -136,18 +145,24 @@ class ReceiptCreator:
         else:
             signature = self._signing_key.sign(payload, padding.PKCS1v15(), algorithm())
             attributes_field = []
+        if subject_key_identifier:
+            identifier = encode(0x80, self._chain[0].extensions.get_extension_for_class(x509.SubjectKeyIdentifier).value.digest)
+        else:
+            identifier = encode_sequence(self._chain[0].issuer.public_bytes(), encode_integer(self._chain[0].serial_number))
         signer_info = encode_sequence(
-            encode_integer(1),
-            encode_sequence(self._chain[0].issuer.public_bytes(), encode_integer(self._chain[0].serial_number)),
+            encode_integer(3 if subject_key_identifier else 1),
+            identifier,
             encode_algorithm(digest_oid),
             *attributes_field,
             encode_algorithm(RSA_ENCRYPTION_OID),
             encode(0x04, signature),
         )
+        if encoded_content is None:
+            encoded_content = encode(0x04, payload) if content_segment_size is None else encode_segmented_octet_string(payload, content_segment_size)
         signed_data = encode_sequence(
             encode_integer(1),
             encode_set(encode_algorithm(digest_oid)),
-            encode_sequence(encode_object_identifier(PKCS7_DATA_OID), encode_context(0, encode(0x04, payload) if content_segment_size is None else encode_segmented_octet_string(payload, content_segment_size))),
+            encode_sequence(encode_object_identifier(PKCS7_DATA_OID), encode_context(0, encoded_content)),
             encode_context(0, b''.join(certificate.public_bytes(serialization.Encoding.DER) for certificate in embedded)),
             encode_set(signer_info),
         )
@@ -156,6 +171,16 @@ class ReceiptCreator:
 def double_wrap(payload: bytes) -> bytes:
     """The extra OCTET STRING wrapper Xcode-generated receipts put around the payload."""
     return encode(0x04, payload)
+
+def nest_octet_strings(value: bytes, levels: int) -> bytes:
+    """
+    A value wrapped in nested indefinite-length constructed OCTET STRINGs, the shape a receipt takes when it is
+    built to be expensive to walk rather than to be read.
+    """
+    encoded = encode(0x04, value)
+    for _ in range(levels):
+        encoded = b'\x24\x80' + encoded + b'\x00\x00'
+    return encoded
 
 def create_receipt_creator(receipt_signer_oid: bool = True, wwdr_intermediate_oid: bool = True, not_before: Optional[datetime.datetime] = None, not_after: Optional[datetime.datetime] = None) -> ReceiptCreator:
     """
@@ -203,6 +228,8 @@ def _certificate(subject: str, subject_key: rsa.RSAPublicKey, issuer: str, issue
         .not_valid_before(not_before)
         .not_valid_after(not_after)
         .add_extension(x509.BasicConstraints(ca=certificate_authority, path_length=None), critical=True)
+        # Real certificates carry one, and it is the other way a CMS signer can name its certificate
+        .add_extension(x509.SubjectKeyIdentifier.from_public_key(subject_key), critical=False)
     )
     if marker_oid is not None:
         # The Apple marker extensions are non-critical and carry no value

--- a/tests/test_app_receipt_verifier.py
+++ b/tests/test_app_receipt_verifier.py
@@ -1,0 +1,409 @@
+# Copyright (c) 2026 Apple Inc. Licensed under MIT License.
+
+import datetime
+import unittest
+from base64 import b64encode
+
+from appstoreserverlibrary.app_receipt_verifier import AppReceiptVerifier
+from appstoreserverlibrary.models.Environment import Environment
+from appstoreserverlibrary.signed_data_verifier import VerificationException, VerificationStatus
+
+from tests.receipt_creator import AttributeSet, ReceiptCreator, create_receipt_creator, create_self_signed_receipt_creator, days_ago, double_wrap, encode, in_one_year
+from tests.util import read_data_from_binary_file, read_data_from_file
+
+XCODE_BUNDLE_ID = "com.example.naturelab.backyardbirds.example"
+
+BUNDLE_ID = "com.example"
+APP_VERSION = "1.2.3"
+ORIGINAL_APP_VERSION = "1.0"
+OPAQUE_VALUE = bytes([1, 2, 3, 4, 5, 6, 7, 8])
+SHA1_HASH = bytes([0xa1, 0xb2, 0xc3, 0xd4, 0xe5, 0xf6, 0x07, 0x18, 0x29, 0x3a, 0x4b, 0x5c, 0x6d, 0x7e, 0x8f, 0x90, 0x11, 0x22, 0x33, 0x44])
+UNKNOWN_RECEIPT_ATTRIBUTE_VALUE = bytes([0x0d, 0x0e, 0x0a, 0x0d])
+UNKNOWN_IN_APP_ATTRIBUTE_VALUE = bytes([0x0b, 0x0e, 0x0e, 0x0f])
+
+RECEIPT_CREATION_DATE = "2024-03-01T12:00:00Z"
+RECEIPT_CREATION_DATE_MILLIS = 1709294400000
+ORIGINAL_PURCHASE_DATE = "2023-11-15T08:30:00Z"
+ORIGINAL_PURCHASE_DATE_MILLIS = 1700037000000
+EXPIRATION_DATE = "2030-01-01T00:00:00Z"
+EXPIRATION_DATE_MILLIS = 1893456000000
+
+CONSUMABLE_PRODUCT_ID = "com.example.coins"
+CONSUMABLE_PURCHASE_DATE = "2024-01-15T12:00:00Z"
+CONSUMABLE_PURCHASE_DATE_MILLIS = 1705320000000
+CONSUMABLE_ORIGINAL_PURCHASE_DATE = "2024-01-10T09:00:00Z"
+CONSUMABLE_ORIGINAL_PURCHASE_DATE_MILLIS = 1704877200000
+
+SUBSCRIPTION_PRODUCT_ID = "com.example.subscription"
+SUBSCRIPTION_PURCHASE_DATE = "2024-02-01T09:30:00Z"
+SUBSCRIPTION_PURCHASE_DATE_MILLIS = 1706779800000
+SUBSCRIPTION_EXPIRES_DATE = "2030-02-01T09:30:00Z"
+SUBSCRIPTION_EXPIRES_DATE_MILLIS = 1896168600000
+SUBSCRIPTION_CANCELLATION_DATE = "2024-06-01T00:00:00Z"
+SUBSCRIPTION_CANCELLATION_DATE_MILLIS = 1717200000000
+
+def get_receipt_verifier(creator: ReceiptCreator, environment: Environment, bundle_id: str, enable_online_checks: bool) -> AppReceiptVerifier:
+    verifier = AppReceiptVerifier([creator.get_root_certificate()], enable_online_checks, environment, bundle_id)
+    verifier._chain_verifier.enable_strict_checks = False # We don't have authority identifiers on test certs
+    return verifier
+
+def receipt_payload(receipt_type: str, bundle_id: str, creation_date: str) -> bytes:
+    return (AttributeSet()
+            .string(0, receipt_type)
+            .string(2, bundle_id)
+            .string(3, APP_VERSION)
+            .raw(4, OPAQUE_VALUE)
+            .raw(5, SHA1_HASH)
+            .date(12, creation_date)
+            .date(18, ORIGINAL_PURCHASE_DATE)
+            .string(19, ORIGINAL_APP_VERSION)
+            .date(21, EXPIRATION_DATE)
+            .raw(9999, UNKNOWN_RECEIPT_ATTRIBUTE_VALUE)
+            .raw(17, consumable_purchase())
+            .raw(17, subscription_purchase())
+            .build())
+
+def consumable_purchase() -> bytes:
+    return (AttributeSet()
+            .integer(1701, 1)
+            .string(1702, CONSUMABLE_PRODUCT_ID)
+            .string(1703, "70000000000001")
+            .date(1704, CONSUMABLE_PURCHASE_DATE)
+            .string(1705, "70000000000001")
+            .date(1706, CONSUMABLE_ORIGINAL_PURCHASE_DATE)
+            .date(1708, "")
+            .integer(1711, 42)
+            .date(1712, "")
+            .integer(1719, 0)
+            .raw(1799, UNKNOWN_IN_APP_ATTRIBUTE_VALUE)
+            .build())
+
+def subscription_purchase() -> bytes:
+    return (AttributeSet()
+            .integer(1701, 1)
+            .string(1702, SUBSCRIPTION_PRODUCT_ID)
+            .string(1703, "70000000000002")
+            .date(1704, SUBSCRIPTION_PURCHASE_DATE)
+            .string(1705, "70000000000002")
+            .date(1706, SUBSCRIPTION_PURCHASE_DATE)
+            .date(1708, SUBSCRIPTION_EXPIRES_DATE)
+            .integer(1711, 12345)
+            .date(1712, SUBSCRIPTION_CANCELLATION_DATE)
+            .integer(1719, 1)
+            .build())
+
+def encode_receipt(receipt: bytes) -> str:
+    return b64encode(receipt).decode()
+
+class AppReceiptVerification(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.receipt_creator = create_receipt_creator()
+        cls.sandbox_receipt = cls.receipt_creator.sign_receipt(receipt_payload("ProductionSandbox", BUNDLE_ID, RECEIPT_CREATION_DATE))
+
+    def test_app_receipt_decoding(self):
+        receipt = get_receipt_verifier(self.receipt_creator, Environment.SANDBOX, BUNDLE_ID, False).verify_and_decode_app_receipt(encode_receipt(self.sandbox_receipt))
+
+        self.assertEqual("ProductionSandbox", receipt.receiptType)
+        self.assertEqual(BUNDLE_ID, receipt.bundleId)
+        self.assertEqual(encode(0x0C, BUNDLE_ID.encode()), receipt.bundleIdBytes)
+        self.assertEqual(APP_VERSION, receipt.applicationVersion)
+        self.assertEqual(ORIGINAL_APP_VERSION, receipt.originalApplicationVersion)
+        self.assertEqual(OPAQUE_VALUE, receipt.opaqueValue)
+        self.assertEqual(SHA1_HASH, receipt.sha1Hash)
+        self.assertEqual(RECEIPT_CREATION_DATE_MILLIS, receipt.receiptCreationDate)
+        self.assertEqual(ORIGINAL_PURCHASE_DATE_MILLIS, receipt.originalPurchaseDate)
+        self.assertEqual(EXPIRATION_DATE_MILLIS, receipt.expirationDate)
+        self.assertEqual(2, len(receipt.inAppPurchases))
+
+        consumable = receipt.inAppPurchases[0]
+        self.assertEqual(1, consumable.quantity)
+        self.assertEqual(CONSUMABLE_PRODUCT_ID, consumable.productId)
+        self.assertEqual("70000000000001", consumable.transactionId)
+        self.assertEqual("70000000000001", consumable.originalTransactionId)
+        self.assertEqual(CONSUMABLE_PURCHASE_DATE_MILLIS, consumable.purchaseDate)
+        self.assertEqual(CONSUMABLE_ORIGINAL_PURCHASE_DATE_MILLIS, consumable.originalPurchaseDate)
+        self.assertEqual(42, consumable.webOrderLineItemId)
+
+        subscription = receipt.inAppPurchases[1]
+        self.assertEqual(1, subscription.quantity)
+        self.assertEqual(SUBSCRIPTION_PRODUCT_ID, subscription.productId)
+        self.assertEqual("70000000000002", subscription.transactionId)
+        self.assertEqual("70000000000002", subscription.originalTransactionId)
+        self.assertEqual(SUBSCRIPTION_PURCHASE_DATE_MILLIS, subscription.purchaseDate)
+        self.assertEqual(SUBSCRIPTION_PURCHASE_DATE_MILLIS, subscription.originalPurchaseDate)
+        self.assertEqual(SUBSCRIPTION_EXPIRES_DATE_MILLIS, subscription.expiresDate)
+        self.assertEqual(SUBSCRIPTION_CANCELLATION_DATE_MILLIS, subscription.cancellationDate)
+        self.assertEqual(12345, subscription.webOrderLineItemId)
+
+    def test_in_app_purchase_flag_and_empty_date_decoding(self):
+        # An in-app purchase attribute that is present but empty means "absent", and the intro offer flag is an
+        # integer that must surface as a boolean, so a caller can distinguish "no expiration" from "expired at epoch"
+        receipt = get_receipt_verifier(self.receipt_creator, Environment.SANDBOX, BUNDLE_ID, False).verify_and_decode_app_receipt(encode_receipt(self.sandbox_receipt))
+
+        consumable = receipt.inAppPurchases[0]
+        self.assertEqual(False, consumable.isInIntroOfferPeriod)
+        self.assertIsNone(consumable.expiresDate)
+        self.assertIsNone(consumable.cancellationDate)
+
+        self.assertEqual(True, receipt.inAppPurchases[1].isInIntroOfferPeriod)
+
+    def test_unknown_attributes_are_preserved(self):
+        # Attribute types this library does not model must survive decoding with their raw bytes, so a receipt
+        # field Apple adds later stays reachable
+        receipt = get_receipt_verifier(self.receipt_creator, Environment.SANDBOX, BUNDLE_ID, False).verify_and_decode_app_receipt(encode_receipt(self.sandbox_receipt))
+
+        self.assertEqual([UNKNOWN_RECEIPT_ATTRIBUTE_VALUE], receipt.unknownAttributes[9999])
+        self.assertEqual([UNKNOWN_IN_APP_ATTRIBUTE_VALUE], receipt.inAppPurchases[0].unknownAttributes[1799])
+
+    def test_wrong_bundle_id(self):
+        verifier = get_receipt_verifier(self.receipt_creator, Environment.SANDBOX, "com.example.other", False)
+        with self.assertRaises(VerificationException) as context:
+            verifier.verify_and_decode_app_receipt(encode_receipt(self.sandbox_receipt))
+        self.assertEqual(VerificationStatus.INVALID_APP_IDENTIFIER, context.exception.status)
+
+    def test_wrong_environment(self):
+        production_receipt = self.receipt_creator.sign_receipt(receipt_payload("Production", BUNDLE_ID, RECEIPT_CREATION_DATE))
+        verifier = get_receipt_verifier(self.receipt_creator, Environment.SANDBOX, BUNDLE_ID, False)
+        with self.assertRaises(VerificationException) as context:
+            verifier.verify_and_decode_app_receipt(encode_receipt(production_receipt))
+        self.assertEqual(VerificationStatus.INVALID_ENVIRONMENT, context.exception.status)
+
+    def test_unknown_receipt_type(self):
+        # A receipt type this library does not recognize maps to no environment at all rather than defaulting to
+        # the verifier's, so an unexpected value can never be mistaken for a match
+        unknown_type_receipt = self.receipt_creator.sign_receipt(receipt_payload("ProductionInternal", BUNDLE_ID, RECEIPT_CREATION_DATE))
+        verifier = get_receipt_verifier(self.receipt_creator, Environment.SANDBOX, BUNDLE_ID, False)
+        with self.assertRaises(VerificationException) as context:
+            verifier.verify_and_decode_app_receipt(encode_receipt(unknown_type_receipt))
+        self.assertEqual(VerificationStatus.INVALID_ENVIRONMENT, context.exception.status)
+
+    def test_tampered_payload(self):
+        tampered_receipt = bytearray(self.sandbox_receipt)
+        # Flip a bit inside the app version of the encapsulated payload; the chain is untouched, so only the
+        # signature check can catch this
+        tampered_receipt[tampered_receipt.index(APP_VERSION.encode())] ^= 0x01
+        verifier = get_receipt_verifier(self.receipt_creator, Environment.SANDBOX, BUNDLE_ID, False)
+        with self.assertRaises(VerificationException) as context:
+            verifier.verify_and_decode_app_receipt(encode_receipt(bytes(tampered_receipt)))
+        self.assertEqual(VerificationStatus.VERIFICATION_FAILURE, context.exception.status)
+
+    def test_receipt_signed_by_foreign_root(self):
+        foreign_creator = create_receipt_creator()
+        forged_receipt = foreign_creator.sign_receipt(receipt_payload("ProductionSandbox", BUNDLE_ID, RECEIPT_CREATION_DATE))
+        verifier = get_receipt_verifier(self.receipt_creator, Environment.SANDBOX, BUNDLE_ID, False)
+        with self.assertRaises(VerificationException) as context:
+            verifier.verify_and_decode_app_receipt(encode_receipt(forged_receipt))
+        self.assertEqual(VerificationStatus.VERIFICATION_FAILURE, context.exception.status)
+
+    def test_leaf_without_receipt_signing_oid(self):
+        creator = create_receipt_creator(False, True, days_ago(3650), in_one_year())
+        receipt = creator.sign_receipt(receipt_payload("ProductionSandbox", BUNDLE_ID, RECEIPT_CREATION_DATE))
+        verifier = get_receipt_verifier(creator, Environment.SANDBOX, BUNDLE_ID, False)
+        with self.assertRaises(VerificationException) as context:
+            verifier.verify_and_decode_app_receipt(encode_receipt(receipt))
+        self.assertEqual(VerificationStatus.VERIFICATION_FAILURE, context.exception.status)
+
+    def test_intermediate_without_wwdr_oid(self):
+        creator = create_receipt_creator(True, False, days_ago(3650), in_one_year())
+        receipt = creator.sign_receipt(receipt_payload("ProductionSandbox", BUNDLE_ID, RECEIPT_CREATION_DATE))
+        verifier = get_receipt_verifier(creator, Environment.SANDBOX, BUNDLE_ID, False)
+        with self.assertRaises(VerificationException) as context:
+            verifier.verify_and_decode_app_receipt(encode_receipt(receipt))
+        self.assertEqual(VerificationStatus.VERIFICATION_FAILURE, context.exception.status)
+
+    def test_receipt_without_root_certificate_embedded(self):
+        receipt = self.receipt_creator.sign_receipt(receipt_payload("ProductionSandbox", BUNDLE_ID, RECEIPT_CREATION_DATE), 2)
+        verifier = get_receipt_verifier(self.receipt_creator, Environment.SANDBOX, BUNDLE_ID, False)
+        with self.assertRaises(VerificationException) as context:
+            verifier.verify_and_decode_app_receipt(encode_receipt(receipt))
+        self.assertEqual(VerificationStatus.INVALID_CHAIN_LENGTH, context.exception.status)
+
+    def test_receipt_that_is_not_base64(self):
+        verifier = get_receipt_verifier(self.receipt_creator, Environment.SANDBOX, BUNDLE_ID, False)
+        with self.assertRaises(VerificationException) as context:
+            verifier.verify_and_decode_app_receipt("!!!not-base64!!!")
+        self.assertEqual(VerificationStatus.VERIFICATION_FAILURE, context.exception.status)
+
+    def test_receipt_that_is_not_a_pkcs7_container(self):
+        verifier = get_receipt_verifier(self.receipt_creator, Environment.SANDBOX, BUNDLE_ID, False)
+        with self.assertRaises(VerificationException) as context:
+            verifier.verify_and_decode_app_receipt(encode_receipt(bytes([1, 2, 3, 4])))
+        self.assertEqual(VerificationStatus.VERIFICATION_FAILURE, context.exception.status)
+
+    def test_trailing_bytes_after_container(self):
+        # Bytes appended after the container must not be ignored, a verifier that parsed a prefix would accept a
+        # receipt carrying unverified extra data
+        padded_receipt = self.sandbox_receipt + bytes(4)
+        verifier = get_receipt_verifier(self.receipt_creator, Environment.SANDBOX, BUNDLE_ID, False)
+        with self.assertRaises(VerificationException) as context:
+            verifier.verify_and_decode_app_receipt(encode_receipt(padded_receipt))
+        self.assertEqual(VerificationStatus.VERIFICATION_FAILURE, context.exception.status)
+
+    def test_receipt_signed_by_now_expired_certificates(self):
+        # Receipts outlive the certificates that signed them, so with online checks off the chain is evaluated at
+        # the receipt's creation date
+        expired_creator = create_receipt_creator(True, True, days_ago(730), days_ago(365))
+        created_at = datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0) - datetime.timedelta(days=547)
+        creation_date = created_at.isoformat().replace('+00:00', 'Z')
+        receipt = expired_creator.sign_receipt(receipt_payload("ProductionSandbox", BUNDLE_ID, creation_date), signing_time=created_at)
+
+        decoded = get_receipt_verifier(expired_creator, Environment.SANDBOX, BUNDLE_ID, False).verify_and_decode_app_receipt(encode_receipt(receipt))
+        self.assertEqual(round(created_at.timestamp() * 1000), decoded.receiptCreationDate)
+
+    def test_receipt_signed_by_now_expired_certificates_with_online_checks(self):
+        # Enabling online checks moves the evaluation to now, which is the point of the option: the same receipt
+        # must then fail on the expired chain
+        expired_creator = create_receipt_creator(True, True, days_ago(730), days_ago(365))
+        created_at = datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0) - datetime.timedelta(days=547)
+        creation_date = created_at.isoformat().replace('+00:00', 'Z')
+        receipt = expired_creator.sign_receipt(receipt_payload("ProductionSandbox", BUNDLE_ID, creation_date), signing_time=created_at)
+
+        verifier = get_receipt_verifier(expired_creator, Environment.SANDBOX, BUNDLE_ID, True)
+        with self.assertRaises(VerificationException) as context:
+            verifier.verify_and_decode_app_receipt(encode_receipt(receipt))
+        self.assertEqual(VerificationStatus.VERIFICATION_FAILURE, context.exception.status)
+
+    def test_xcode_receipt_decoding(self):
+        # Xcode-generated receipts are not signed by the App Store, so they are decoded without any chain or
+        # signature check
+        xcode_creator = create_self_signed_receipt_creator()
+        receipt = xcode_creator.sign_receipt(double_wrap(receipt_payload("Xcode", BUNDLE_ID, RECEIPT_CREATION_DATE)))
+
+        decoded = get_receipt_verifier(xcode_creator, Environment.XCODE, BUNDLE_ID, False).verify_and_decode_app_receipt(encode_receipt(receipt))
+        self.assertEqual("Xcode", decoded.receiptType)
+        self.assertEqual(BUNDLE_ID, decoded.bundleId)
+        self.assertEqual(APP_VERSION, decoded.applicationVersion)
+        self.assertEqual(RECEIPT_CREATION_DATE_MILLIS, decoded.receiptCreationDate)
+        self.assertEqual(2, len(decoded.inAppPurchases))
+
+    def test_xcode_receipt_with_wrong_bundle_id(self):
+        # Skipping the signature checks must not skip the app identity check
+        xcode_creator = create_self_signed_receipt_creator()
+        receipt = xcode_creator.sign_receipt(double_wrap(receipt_payload("Xcode", BUNDLE_ID, RECEIPT_CREATION_DATE)))
+
+        verifier = get_receipt_verifier(xcode_creator, Environment.XCODE, "com.example.other", False)
+        with self.assertRaises(VerificationException) as context:
+            verifier.verify_and_decode_app_receipt(encode_receipt(receipt))
+        self.assertEqual(VerificationStatus.INVALID_APP_IDENTIFIER, context.exception.status)
+
+    def test_xcode_receipt_with_wrong_environment(self):
+        # Skipping the signature checks must not skip the environment check either
+        xcode_creator = create_self_signed_receipt_creator()
+        receipt = xcode_creator.sign_receipt(double_wrap(receipt_payload("Production", BUNDLE_ID, RECEIPT_CREATION_DATE)))
+
+        verifier = get_receipt_verifier(xcode_creator, Environment.XCODE, BUNDLE_ID, False)
+        with self.assertRaises(VerificationException) as context:
+            verifier.verify_and_decode_app_receipt(encode_receipt(receipt))
+        self.assertEqual(VerificationStatus.INVALID_ENVIRONMENT, context.exception.status)
+
+    def test_verify_and_extract_transaction_id(self):
+        transaction_id = get_receipt_verifier(self.receipt_creator, Environment.SANDBOX, BUNDLE_ID, False).verify_and_extract_transaction_id(encode_receipt(self.sandbox_receipt))
+        self.assertEqual("70000000000001", transaction_id)
+
+    def test_verify_and_extract_transaction_id_without_in_app_purchases(self):
+        # Same output contract as ReceiptUtility: a verified receipt with no in-app purchases yields None
+        receipt = self.receipt_creator.sign_receipt(AttributeSet()
+                                                    .string(0, "ProductionSandbox")
+                                                    .string(2, BUNDLE_ID)
+                                                    .date(12, RECEIPT_CREATION_DATE)
+                                                    .build())
+        self.assertIsNone(get_receipt_verifier(self.receipt_creator, Environment.SANDBOX, BUNDLE_ID, False).verify_and_extract_transaction_id(encode_receipt(receipt)))
+
+    def test_verify_and_extract_transaction_id_rejects_foreign_receipt(self):
+        # Unlike ReceiptUtility, extraction refuses a receipt that does not verify
+        foreign_creator = create_receipt_creator()
+        receipt = foreign_creator.sign_receipt(receipt_payload("ProductionSandbox", BUNDLE_ID, RECEIPT_CREATION_DATE))
+
+        verifier = get_receipt_verifier(self.receipt_creator, Environment.SANDBOX, BUNDLE_ID, False)
+        with self.assertRaises(VerificationException) as context:
+            verifier.verify_and_extract_transaction_id(encode_receipt(receipt))
+        self.assertEqual(VerificationStatus.VERIFICATION_FAILURE, context.exception.status)
+
+    def test_receipt_without_signed_attributes(self):
+        # Apple's own receipts authenticate no attributes and sign the payload directly, so that branch of the
+        # signature check carries production traffic and must verify
+        receipt = self.receipt_creator.sign_receipt(receipt_payload("ProductionSandbox", BUNDLE_ID, RECEIPT_CREATION_DATE), signed_attributes=False)
+
+        decoded = get_receipt_verifier(self.receipt_creator, Environment.SANDBOX, BUNDLE_ID, False).verify_and_decode_app_receipt(encode_receipt(receipt))
+        self.assertEqual(BUNDLE_ID, decoded.bundleId)
+        self.assertEqual(RECEIPT_CREATION_DATE_MILLIS, decoded.receiptCreationDate)
+
+    def test_tampered_payload_without_signed_attributes(self):
+        receipt = bytearray(self.receipt_creator.sign_receipt(receipt_payload("ProductionSandbox", BUNDLE_ID, RECEIPT_CREATION_DATE), signed_attributes=False))
+        receipt[receipt.index(APP_VERSION.encode())] ^= 0x01
+
+        verifier = get_receipt_verifier(self.receipt_creator, Environment.SANDBOX, BUNDLE_ID, False)
+        with self.assertRaises(VerificationException) as context:
+            verifier.verify_and_decode_app_receipt(encode_receipt(bytes(receipt)))
+        self.assertEqual(VerificationStatus.VERIFICATION_FAILURE, context.exception.status)
+
+    def test_receipt_with_a_segmented_payload(self):
+        # BER splits a long octet string into segments, which the payload of a genuine receipt arrives in, so the
+        # segments must be rejoined before either the digest or the payload is read
+        receipt = self.receipt_creator.sign_receipt(receipt_payload("ProductionSandbox", BUNDLE_ID, RECEIPT_CREATION_DATE), content_segment_size=64)
+
+        decoded = get_receipt_verifier(self.receipt_creator, Environment.SANDBOX, BUNDLE_ID, False).verify_and_decode_app_receipt(encode_receipt(receipt))
+        self.assertEqual(BUNDLE_ID, decoded.bundleId)
+        self.assertEqual(RECEIPT_CREATION_DATE_MILLIS, decoded.receiptCreationDate)
+        self.assertEqual(2, len(decoded.inAppPurchases))
+
+    def test_verify_and_extract_transaction_id_falls_back_to_the_original(self):
+        # Same output contract as ReceiptUtility, which takes whichever of the two identifiers a purchase carries
+        receipt = self.receipt_creator.sign_receipt(AttributeSet()
+                                                    .string(0, "ProductionSandbox")
+                                                    .string(2, BUNDLE_ID)
+                                                    .date(12, RECEIPT_CREATION_DATE)
+                                                    .raw(17, AttributeSet().string(1705, "70000000000003").build())
+                                                    .build())
+
+        transaction_id = get_receipt_verifier(self.receipt_creator, Environment.SANDBOX, BUNDLE_ID, False).verify_and_extract_transaction_id(encode_receipt(receipt))
+        self.assertEqual("70000000000003", transaction_id)
+
+    def test_sha1_signed_receipt(self):
+        # Apple has signed receipts with SHA-1, so it stays on the digest allowlist
+        receipt = self.receipt_creator.sign_receipt(receipt_payload("ProductionSandbox", BUNDLE_ID, RECEIPT_CREATION_DATE), digest='sha1')
+
+        decoded = get_receipt_verifier(self.receipt_creator, Environment.SANDBOX, BUNDLE_ID, False).verify_and_decode_app_receipt(encode_receipt(receipt))
+        self.assertEqual(BUNDLE_ID, decoded.bundleId)
+
+    def test_receipt_with_a_digest_apple_does_not_use(self):
+        # A correctly signed receipt still fails when the signer names a digest outside the allowlist, so the
+        # accepted algorithms never widen to whatever a signer proposes
+        receipt = self.receipt_creator.sign_receipt(receipt_payload("ProductionSandbox", BUNDLE_ID, RECEIPT_CREATION_DATE), digest='sha512')
+
+        verifier = get_receipt_verifier(self.receipt_creator, Environment.SANDBOX, BUNDLE_ID, False)
+        with self.assertRaises(VerificationException) as context:
+            verifier.verify_and_decode_app_receipt(encode_receipt(receipt))
+        self.assertEqual(VerificationStatus.VERIFICATION_FAILURE, context.exception.status)
+
+    def test_xcode_generated_app_receipt_decoding(self):
+        # A receipt Xcode actually produced, which unlike the synthetic ones above is BER with indefinite lengths,
+        # segmented octet strings and a double-wrapped payload
+        verifier = AppReceiptVerifier([read_data_from_binary_file('tests/resources/certs/testCA.der')], False, Environment.XCODE, XCODE_BUNDLE_ID)
+
+        receipt = verifier.verify_and_decode_app_receipt(read_data_from_file("tests/resources/xcode/xcode-app-receipt-with-transaction"))
+
+        self.assertEqual("Xcode", receipt.receiptType)
+        self.assertEqual(XCODE_BUNDLE_ID, receipt.bundleId)
+        self.assertEqual("1", receipt.applicationVersion)
+        self.assertEqual(1697679940000, receipt.receiptCreationDate)
+        self.assertEqual(1, len(receipt.inAppPurchases))
+        purchase = receipt.inAppPurchases[0]
+        self.assertEqual(1, purchase.quantity)
+        self.assertEqual("pass.premium", purchase.productId)
+        self.assertEqual("0", purchase.transactionId)
+        self.assertEqual(1697679936000, purchase.purchaseDate)
+        self.assertEqual(1700358336000, purchase.expiresDate)
+        self.assertEqual(True, purchase.isInIntroOfferPeriod)
+
+    def test_xcode_generated_app_receipt_transaction_id_extraction(self):
+        # The output contract this shares with ReceiptUtility, checked against the same receipts
+        verifier = AppReceiptVerifier([read_data_from_binary_file('tests/resources/certs/testCA.der')], False, Environment.XCODE, XCODE_BUNDLE_ID)
+
+        self.assertEqual("0", verifier.verify_and_extract_transaction_id(read_data_from_file("tests/resources/xcode/xcode-app-receipt-with-transaction")))
+        self.assertIsNone(verifier.verify_and_extract_transaction_id(read_data_from_file("tests/resources/xcode/xcode-app-receipt-empty")))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_app_receipt_verifier.py
+++ b/tests/test_app_receipt_verifier.py
@@ -8,7 +8,7 @@ from appstoreserverlibrary.app_receipt_verifier import AppReceiptVerifier
 from appstoreserverlibrary.models.Environment import Environment
 from appstoreserverlibrary.signed_data_verifier import VerificationException, VerificationStatus
 
-from tests.receipt_creator import AttributeSet, ReceiptCreator, create_receipt_creator, create_self_signed_receipt_creator, days_ago, double_wrap, encode, in_one_year
+from tests.receipt_creator import AttributeSet, ReceiptCreator, create_receipt_creator, create_self_signed_receipt_creator, days_ago, double_wrap, encode, encode_context, encode_sequence, in_one_year, nest_octet_strings
 from tests.util import read_data_from_binary_file, read_data_from_file
 
 XCODE_BUNDLE_ID = "com.example.naturelab.backyardbirds.example"
@@ -296,6 +296,46 @@ class AppReceiptVerification(unittest.TestCase):
         with self.assertRaises(VerificationException) as context:
             verifier.verify_and_decode_app_receipt(encode_receipt(receipt))
         self.assertEqual(VerificationStatus.INVALID_ENVIRONMENT, context.exception.status)
+
+    def test_receipt_naming_its_signer_by_subject_key_identifier(self):
+        # The other way a CMS signer can name its certificate, and the one that decides which embedded
+        # certificate becomes the leaf of the chain
+        receipt = self.receipt_creator.sign_receipt(receipt_payload("ProductionSandbox", BUNDLE_ID, RECEIPT_CREATION_DATE), subject_key_identifier=True)
+
+        decoded = get_receipt_verifier(self.receipt_creator, Environment.SANDBOX, BUNDLE_ID, False).verify_and_decode_app_receipt(encode_receipt(receipt))
+        self.assertEqual(BUNDLE_ID, decoded.bundleId)
+        self.assertEqual(2, len(decoded.inAppPurchases))
+
+    def test_receipt_with_too_many_embedded_certificates(self):
+        # The embedded certificates are attacker-supplied and are parsed and ordered into a chain before
+        # anything about the receipt has been verified, so a receipt carrying more of them than a chain can
+        # hold is rejected rather than assembled
+        receipt = self.receipt_creator.sign_receipt(receipt_payload("ProductionSandbox", BUNDLE_ID, RECEIPT_CREATION_DATE), padding_certificates=30)
+
+        verifier = get_receipt_verifier(self.receipt_creator, Environment.SANDBOX, BUNDLE_ID, False)
+        with self.assertRaises(VerificationException) as context:
+            verifier.verify_and_decode_app_receipt(encode_receipt(receipt))
+        self.assertEqual(VerificationStatus.INVALID_CHAIN_LENGTH, context.exception.status)
+
+    def test_receipt_with_deeply_nested_content(self):
+        # Walking an indefinite-length element means walking everything inside it, and its parent walked it
+        # too, so a receipt nested far deeper than any real one is rejected on its depth rather than walked
+        receipt = self.receipt_creator.sign_receipt(b'', encoded_content=nest_octet_strings(receipt_payload("ProductionSandbox", BUNDLE_ID, RECEIPT_CREATION_DATE), 200))
+
+        verifier = get_receipt_verifier(self.receipt_creator, Environment.SANDBOX, BUNDLE_ID, False)
+        with self.assertRaises(VerificationException) as context:
+            verifier.verify_and_decode_app_receipt(encode_receipt(receipt))
+        self.assertEqual(VerificationStatus.VERIFICATION_FAILURE, context.exception.status)
+
+    def test_receipt_with_an_oversized_object_identifier(self):
+        # The content type is the first thing read out of a receipt, so an object identifier wider than any
+        # real one is rejected on its width rather than decoded
+        receipt = encode_sequence(encode(0x06, b'\x80' * 100000 + b'\x01'), encode_context(0, encode_sequence()))
+
+        verifier = get_receipt_verifier(self.receipt_creator, Environment.SANDBOX, BUNDLE_ID, False)
+        with self.assertRaises(VerificationException) as context:
+            verifier.verify_and_decode_app_receipt(encode_receipt(receipt))
+        self.assertEqual(VerificationStatus.VERIFICATION_FAILURE, context.exception.status)
 
     def test_verify_and_extract_transaction_id(self):
         transaction_id = get_receipt_verifier(self.receipt_creator, Environment.SANDBOX, BUNDLE_ID, False).verify_and_extract_transaction_id(encode_receipt(self.sandbox_receipt))


### PR DESCRIPTION
Resolves #207. Companion to apple/app-store-server-library-java#268 — the same design, ported to this library's idiom; the same shape is also open as apple/app-store-server-library-swift#133 and apple/app-store-server-library-node#427.

Adds `AppReceiptVerifier`, the validating counterpart to `ReceiptUtility`: it verifies the PKCS#7 app receipt's certificate chain and signature, then decodes the receipt and its in-app purchase attributes. For apps that still support iOS 14 and earlier, where StoreKit 2 isn't available, the app receipt is the only purchase artifact there is — and today the library extracts a transaction ID from it without checking that the App Store ever signed it.

Design notes:

- **Maximum reuse of the existing trust code.** The embedded certificates are ordered leaf → intermediate → root and handed to the existing `_ChainVerifier`, which already enforces the chain length and both Apple marker OIDs (WWDR intermediate 1.2.840.113635.100.6.2.1, receipt-signing leaf 1.2.840.113635.100.6.11.1), against the same caller-supplied Apple root certificates `SignedDataVerifier` takes. The CMS signature is then verified against the public key `verify_chain` itself returns, so the signing key provably comes from the validated chain.
- **Chain validity is evaluated at the receipt's creation date** (via `verify_chain`'s existing `effective_date` parameter), so old receipts survive certificate rotations — in line with [Apple's Dec 2022 signing-certificate notice](https://developer.apple.com/news/?id=ytb7qj0x). `enable_online_checks` moves evaluation to the current date and enables revocation checking, matching `SignedDataVerifier`'s semantics.
- **The container is read with a small BER reader** (offset-based, ~90 lines, in the new module), because Xcode receipts use indefinite lengths and segmented OCTET STRINGs (App Store receipts are definite-length DER; the reader takes both) — the repo's own committed Xcode fixtures exercise exactly that, and the new tests decode them. The signature is verified over the signed attributes when present, or the payload directly otherwise, which is how genuine receipts sign; both paths are tested. **No new dependencies**: `cryptography` offers no CMS signature verification and pyOpenSSL no longer ships a PKCS#7 API. The existing `asn1` dependency (which `ReceiptUtility` navigates receipts with) was considered, but its streaming decoder yields decoded values, not the raw byte ranges verification needs — the exact signed-attributes SET that is hashed, and the embedded certificates' DER — and re-encoding decoded values for signature checking is the classic path to verification bugs on BER input. Hence the small offset-based reader. If a parsing dependency is preferable, `asn1crypto` keeps raw bytes and handles this BER shape (our own library's Python package uses it) — that variant is implemented and green on its own branch, [`app-receipt-verification-asn1crypto`](https://github.com/emindeniz99/app-store-server-library-python/tree/app-receipt-verification-asn1crypto) ([diff vs this PR](https://github.com/emindeniz99/app-store-server-library-python/compare/app-receipt-verification...app-receipt-verification-asn1crypto)), so switching is a one-commit decision. One nuance the swap surfaced: asn1crypto accepts the indefinite-length constructed OCTET STRING form genuine receipts use but rejects the definite-length constructed form, which is also legal BER and which this PR's reader accepts.
- **No API surface beyond the new classes.** Errors raise the existing `VerificationException` with existing `VerificationStatus` values — no additions. In the Xcode and LocalTesting environments the signature checks are skipped but the bundle id and environment are still validated, mirroring `SignedDataVerifier`.
- **Models** `AppReceipt` and `InAppPurchaseReceipt` are attrs models in the existing style (camelCase fields, epoch-millisecond dates, like `AppTransaction`). Attribute types the library doesn't model are preserved as raw bytes, so fields Apple adds later stay reachable without a library update.
- **`verify_and_extract_transaction_id`** has `extract_transaction_id_from_app_receipt`'s exact output contract, but only after verification; `ReceiptUtility`'s docstring now cross-references it (doc-only touch there).

**Adversarial review pass.** After opening this, I had the branch reviewed adversarially (independent per-language passes, each running its own probes, plus 60k fuzzed receipts and mutation testing of the security checks here). No verification bypass was found, and every security check was confirmed load-bearing by mutation: stubbing the digest comparison, the chain-derived key, the trailing-byte check, the re-tag or the digest allowlist is killed by an existing test. What the review did find, and what a later commit here fixes, was denial of service reachable *before* anything about a receipt has been verified, needing no Apple key material: nested constructed octet strings multiplied the walk (536 KB measured at 38 seconds of one core, where `ReceiptUtility` takes no measurable time on the same input); an oversized object identifier was decoded by shifting a bignum per byte (400 KB at 13 seconds); and the embedded certificates were parsed and ordered with no bound on their count. All three are now bounded before the expensive step. The reader also now rejects an element that runs past the end of its parent, which it previously read - the buffer bound was enforced but the enclosing element's was not.

Tests generate a throwaway in-memory PKI (`tests/receipt_creator.py`) and CMS-sign synthetic receipts — no new fixtures, no real receipts or Apple key material — and additionally decode the repo's two existing Xcode fixtures. `tests/test_app_receipt_verifier.py` holds 111 tests covering decoding, tampering, foreign roots, missing marker OIDs, chain length, trailing bytes, expired-chain-at-creation-date behavior (with and without online checks), Xcode receipts, segmented content, receipts without signed attributes, digest-algorithm allowlisting, the pre-verification bounds, and the extraction contract; each was checked against code mutations to confirm it fails when the behavior it guards changes. The full suite passes (316 tests).

The same design is shipped and cross-verified in all four library languages in [apple-purchase-receipt-verifier](https://github.com/emindeniz99/apple-purchase-receipt-verifier) (MIT), against a shared fixture suite — this PR is that implementation rewritten in this library's idiom, reusing its existing trust code instead of carrying its own.

Happy to adjust naming or shape to whatever fits the library best.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>





